### PR TITLE
Force Julia to only use pyjulia cache path

### DIFF
--- a/julia/core.py
+++ b/julia/core.py
@@ -342,7 +342,7 @@ class Julia(object):
                 # one must remove the original cache directory to ensure none of the caches there are used
                 # uncomment the following line to attempt to use original cache
                 # be warned: incomapitble cache files will cause a segfault.
-                self._call(u"for i in 1:length(Base.LOAD_CACHE_PATH) pop!(Base.LOAD_CACHE_PATH) end")
+                self._call(u"empty!(Base.LOAD_CACHE_PATH)")
                 self._call(u"unshift!(Base.LOAD_CACHE_PATH, abspath(Pkg.Dir._pkgroot()," +
                     "\"lib\", \"pyjulia%s-v$(VERSION.major).$(VERSION.minor)\"))" % sys.version_info[0])
                 # If PyCall.ji does not exist, create an empty file to force

--- a/julia/core.py
+++ b/julia/core.py
@@ -339,6 +339,10 @@ class Julia(object):
                 self._call(u"eval(Base,:(JULIA_HOME=\""+PYCALL_JULIA_HOME+"\"))")
                 # Add a private cache directory. PyCall needs a different
                 # configuration and so do any packages that depend on it.
+                # one must remove the original cache directory to ensure none of the caches there are used
+                # uncomment the following line to attempt to use original cache
+                # be warned: incomapitble cache files will cause a segfault.
+                self._call(u"for i in 1:length(Base.LOAD_CACHE_PATH) pop!(Base.LOAD_CACHE_PATH) end")
                 self._call(u"unshift!(Base.LOAD_CACHE_PATH, abspath(Pkg.Dir._pkgroot()," +
                     "\"lib\", \"pyjulia%s-v$(VERSION.major).$(VERSION.minor)\"))" % sys.version_info[0])
                 # If PyCall.ji does not exist, create an empty file to force


### PR DESCRIPTION
This forces `Base.LOAD_CACHE_PATH` to only point to the directory with binaries specific to pyjulia and fixes #92.  This solution is certainly not ideal because it forces recompilation of absolutely everything, but previously many (if not most) users would experience a segfault when they start pyjulia for the first time.  

A permanent solution would be either  Julia adding functionality to set the cache path for individual modules, or pyjulia making changes to `Base.LOAD_CACHE_PATH` every time it loads a module.  It seems to me that the best way to implement the latter solution would be to add a special macro to PyCall which pyjulia would use instead of `using`.

The reason for the very strange line 345 is because Julia does not allow you to assign variables in other modules, and I wasn't able to find a single Julia function for emptying an array.  If somebody knows of one I will of course change it.

Note that this does **not** fix #89, which I really don't understand.