### PR TITLE
Package license file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include LICENSE.md

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [bdist_wheel]
 universal=1
+[metadata]
+license_file = LICENSE.md


### PR DESCRIPTION
Ensure the license file is packaged with `sdist`s and `wheel`s.