### PR TITLE
Fix exception printing

### DIFF
--- a/julia/magic.py
+++ b/julia/magic.py
@@ -60,7 +60,7 @@ class JuliaMagics(Magics):
         try:
             ans = self.julia.eval(src)
         except JuliaError as e:
-            print(e.message, file=sys.stderr)
+            print(e, file=sys.stderr)
             ans = None
 
         return ans


### PR DESCRIPTION
The Julia exception objects don't have a `.message` attribute, we can just print the plain object.