### PR TITLE
Make module loading lazy

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,23 +58,70 @@ If you run into problems using `pyjulia`, first check the version of `PyCall.jl`
 
 Usage
 -----
-To call Julia functions from python, first import the library
+
+`pyjulia` provides a high-level interface which assumes a "normal"
+setup (e.g., `julia` is in your `PATH`) and a low-level interface
+which can be used in a customized setup.
+
+### High-level interface
+
+To call a Julia function in Julia module, import the Julia module (say
+`Base`) by:
 
 ```python
-import julia
+from julia import Base
 ```
 
-then create a Julia object that makes a bridge to the Julia interpreter (assuming that `julia` is in your `PATH`)
+and then call Julia functions in `Base` from python, e.g.,
 
 ```python
-j = julia.Julia()
+Base.sind(90)
 ```
 
-You can then call Julia functions from python, e.g.
+Other variants of Python import syntax also work:
 
 ```python
-j.sind(90)
+import julia.Base
+from julia.Base import LinAlg   # import a submodule
+from julia.Base import sin      # import a function from a module
 ```
+
+The global namespace of Julia's interpreter can be accessed via a
+special module `julia.Main`:
+
+```python
+from julia import Main
+```
+
+You can set names in this module to send Python values to Julia:
+
+```python
+Main.xs = [1, 2, 3]
+```
+
+so that, e.g., it can be evaluated at Julia side using Julia syntax:
+
+```python
+Main.eval("sin.(xs)")
+```
+
+### Low-level interface
+
+If you need a custom setup for `pyjulia`, it must be done *before* any
+imports of Julia modules.  For example, to use Julia interpreter at
+`PATH/TO/MY/CUSTOM/julia`, run:
+
+```python
+from julia import Julia
+j = julia.Julia(jl_runtime_path="PATH/TO/MY/CUSTOM/julia")
+```
+
+You can then use, e.g.,
+
+```python
+from julia import Base
+```
+
 
 How it works
 ------------

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ which can be used in a customized setup.
 
 ### High-level interface
 
-To call a Julia function in Julia module, import the Julia module (say
-`Base`) by:
+To call a Julia function in a Julia module, import the Julia module
+(say `Base`) with:
 
 ```python
 from julia import Base
@@ -99,7 +99,8 @@ You can set names in this module to send Python values to Julia:
 Main.xs = [1, 2, 3]
 ```
 
-so that, e.g., it can be evaluated at Julia side using Julia syntax:
+which allows it to be accessed directly from Julia code, e.g., it can
+be evaluated at Julia side using Julia syntax:
 
 ```python
 Main.eval("sin.(xs)")
@@ -107,9 +108,9 @@ Main.eval("sin.(xs)")
 
 ### Low-level interface
 
-If you need a custom setup for `pyjulia`, it must be done *before* any
-imports of Julia modules.  For example, to use Julia interpreter at
-`PATH/TO/MY/CUSTOM/julia`, run:
+If you need a custom setup for `pyjulia`, it must be done *before*
+importing any Julia modules.  For example, to use the Julia
+interpreter at `PATH/TO/MY/CUSTOM/julia`, run:
 
 ```python
 from julia import Julia

--- a/julia/__init__.py
+++ b/julia/__init__.py
@@ -1,1 +1,1 @@
-from .core import Julia, JuliaError
+from .core import JuliaError, LegacyJulia as Julia

--- a/julia/core.py
+++ b/julia/core.py
@@ -41,6 +41,8 @@ if python_version.major == 3:
 else:
     iteritems = dict.iteritems
 
+""" Original environment variables; Used in tests. """
+_orig_env = os.environ.copy()
 
 class JuliaError(Exception):
     pass

--- a/julia/core.py
+++ b/julia/core.py
@@ -58,6 +58,13 @@ class JuliaModule(ModuleType):
         self._julia = loader.julia
         self.__loader__ = loader
 
+    @property
+    def __all__(self):
+        juliapath = self.__name__.lstrip("julia.")
+        names = set(self._julia.eval("names({})".format(juliapath)))
+        names.discard(juliapath.rsplit('.', 1)[-1])
+        return list(names)
+
     def __getattr__(self, name):
         try:
             return self.__try_getattr(name)

--- a/julia/core.py
+++ b/julia/core.py
@@ -114,6 +114,8 @@ class JuliaMainModule(JuliaModule):
             '''.format(juliapath, jl_name(name))
             self._julia.eval(setter)(value)
 
+    help = property(lambda self: self._julia.help)
+    eval = property(lambda self: self._julia.eval)
     using = property(lambda self: self._julia.using)
 
 

--- a/julia/core.py
+++ b/julia/core.py
@@ -41,9 +41,6 @@ if python_version.major == 3:
 else:
     iteritems = dict.iteritems
 
-""" Original environment variables; Used in tests. """
-_orig_env = os.environ.copy()
-
 class JuliaError(Exception):
     pass
 

--- a/julia/core.py
+++ b/julia/core.py
@@ -119,21 +119,21 @@ class JuliaMainModule(JuliaModule):
 
 # add custom import behavior for the julia "module"
 class JuliaImporter(object):
-    def __init__(self, julia):
-        self.julia = julia
 
     # find_module was deprecated in v3.4
     def find_module(self, fullname, path=None):
         if path is None:
             pass
         if fullname.startswith("julia."):
-            return JuliaModuleLoader(self.julia)
+            return JuliaModuleLoader()
 
 
 class JuliaModuleLoader(object):
 
-    def __init__(self, julia):
-        self.julia = julia
+    @property
+    def julia(self):
+        self.__class__.julia = julia = Julia()
+        return julia
 
     # load module was deprecated in v3.4
     def load_module(self, fullname):
@@ -392,8 +392,6 @@ class Julia(object):
         # reloads.
         _julia_runtime[0] = self.api
 
-        sys.meta_path.append(JuliaImporter(self))
-
     def __getattr__(self, name):
         from julia import Main
         warnings.warn(
@@ -489,3 +487,6 @@ class Julia(object):
     def using(self, module):
         """Load module in Julia by calling the `using module` command"""
         self.eval("using %s" % module)
+
+
+sys.meta_path.append(JuliaImporter())

--- a/julia/core.py
+++ b/julia/core.py
@@ -140,8 +140,6 @@ class JuliaImporter(object):
 
     # find_module was deprecated in v3.4
     def find_module(self, fullname, path=None):
-        if path is None:
-            pass
         if fullname.startswith("julia."):
             return JuliaModuleLoader()
 

--- a/julia/core.py
+++ b/julia/core.py
@@ -83,7 +83,7 @@ class JuliaModule(ModuleType):
                     newpath = ".".join((self.__name__, name))
                     return self.__loader__.load_module(newpath)
             return self._julia.eval(module_path)
-        except Exception:
+        except JuliaError:
             if isafunction(self._julia, name, mod_name=juliapath):
                 func = "{}.{}".format(juliapath, name)
                 return self._julia.eval(func)

--- a/test/_star_import.py
+++ b/test/_star_import.py
@@ -1,1 +1,1 @@
-from julia.Base.REPL import *
+from julia.Base.Enums import *

--- a/test/_star_import.py
+++ b/test/_star_import.py
@@ -1,0 +1,1 @@
+from julia.Base.REPL import *

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -85,6 +85,10 @@ class JuliaTest(unittest.TestCase):
         from julia.Base import REPL
         assert isinstance(REPL, ModuleType)
 
+    def test_star_import_julia_module(self):
+        from . import _star_import
+        _star_import.BasicREPL
+
     #TODO: this causes a segfault
     """
     def test_import_julia_modules(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,6 +1,7 @@
 import array
 import math
 import unittest
+from types import ModuleType
 
 from julia import Julia, JuliaError
 import sys
@@ -61,6 +62,28 @@ class JuliaTest(unittest.TestCase):
             self.assertEqual(6, julia_sum([1, 2, 3]))
         else:
             pass
+
+    def test_import_julia_module_existing_function(self):
+        from julia import Base
+        assert Base.mod(2, 2) == 0
+
+    def test_import_julia_module_non_existing_name(self):
+        from julia import Base
+        try:
+            Base.spamspamspam
+            self.fail('No AttributeError')
+        except AttributeError:
+            pass
+
+    def test_julia_module_bang(self):
+        from julia import Base
+        xs = [1, 2, 3]
+        ys = Base.scale_b(xs[:], 2)
+        assert all(x * 2 == y for x, y in zip(xs, ys))
+
+    def test_import_julia_submodule(self):
+        from julia.Base import REPL
+        assert isinstance(REPL, ModuleType)
 
     #TODO: this causes a segfault
     """

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import array
 import math
 import subprocess
@@ -5,7 +7,7 @@ import unittest
 from types import ModuleType
 
 from julia import Julia, JuliaError
-from julia.core import jl_name, py_name
+from julia.core import jl_name, py_name, _orig_env
 import sys
 import os
 
@@ -105,8 +107,9 @@ class JuliaTest(unittest.TestCase):
         assert 'resize_b' in dir(Base)
 
     def test_import_without_setup(self):
-        subprocess.check_call(
-            [sys.executable, '-c', 'from julia import Base'])
+        command = [sys.executable, '-c', 'from julia import Base']
+        print('Executing:', *command)
+        subprocess.check_call(command, env=_orig_env)
 
     #TODO: this causes a segfault
     """

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -7,13 +7,14 @@ import unittest
 from types import ModuleType
 
 from julia import Julia, JuliaError
-from julia.core import jl_name, py_name, _orig_env
+from julia.core import jl_name, py_name
 import sys
 import os
 
 python_version = sys.version_info
 
 
+orig_env = os.environ.copy()
 julia = Julia(jl_runtime_path=os.getenv("JULIA_EXE"), debug=True)
 
 class JuliaTest(unittest.TestCase):
@@ -109,7 +110,7 @@ class JuliaTest(unittest.TestCase):
     def test_import_without_setup(self):
         command = [sys.executable, '-c', 'from julia import Base']
         print('Executing:', *command)
-        subprocess.check_call(command, env=_orig_env)
+        subprocess.check_call(command, env=orig_env)
 
     #TODO: this causes a segfault
     """

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -87,12 +87,12 @@ class JuliaTest(unittest.TestCase):
         assert all(x * 2 == y for x, y in zip(xs, ys))
 
     def test_import_julia_submodule(self):
-        from julia.Base import REPL
-        assert isinstance(REPL, ModuleType)
+        from julia.Base import Enums
+        assert isinstance(Enums, ModuleType)
 
     def test_star_import_julia_module(self):
         from . import _star_import
-        _star_import.BasicREPL
+        _star_import.Enum
 
     def test_main_module(self):
         from julia import Main

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -72,6 +72,10 @@ class JuliaTest(unittest.TestCase):
         from julia import Base
         assert Base.mod(2, 2) == 0
 
+    def test_from_import_existing_julia_function(self):
+        from julia.Base import divrem
+        assert divrem(7, 3) == (2, 1)
+
     def test_import_julia_module_non_existing_name(self):
         from julia import Base
         try:
@@ -79,6 +83,14 @@ class JuliaTest(unittest.TestCase):
             self.fail('No AttributeError')
         except AttributeError:
             pass
+
+    def test_from_import_non_existing_julia_name(self):
+        try:
+            from Base import spamspamspam
+        except ImportError:
+            pass
+        else:
+            assert not spamspamspam
 
     def test_julia_module_bang(self):
         from julia import Base

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -5,6 +5,7 @@ import unittest
 from types import ModuleType
 
 from julia import Julia, JuliaError
+from julia.core import jl_name, py_name
 import sys
 import os
 
@@ -95,6 +96,14 @@ class JuliaTest(unittest.TestCase):
         Main.x = x = 123456
         assert julia.eval('x') == x
 
+    def test_module_all(self):
+        from julia import Base
+        assert 'resize_b' in Base.__all__
+
+    def test_module_dir(self):
+        from julia import Base
+        assert 'resize_b' in dir(Base)
+
     def test_import_without_setup(self):
         subprocess.check_call(
             [sys.executable, '-c', 'from julia import Base'])
@@ -105,3 +114,11 @@ class JuliaTest(unittest.TestCase):
         import julia.PyCall as pycall
         self.assertEquals(6, pycall.pyeval('2 * 3'))
     """
+
+    def test_jlpy_identity(self):
+        for name in ['normal', 'resize!']:
+            self.assertEqual(jl_name(py_name(name)), name)
+
+    def test_pyjl_identity(self):
+        for name in ['normal', 'resize_b']:
+            self.assertEqual(py_name(jl_name(name)), name)

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -89,6 +89,11 @@ class JuliaTest(unittest.TestCase):
         from . import _star_import
         _star_import.BasicREPL
 
+    def test_main_module(self):
+        from julia import Main
+        Main.x = x = 123456
+        assert julia.eval('x') == x
+
     #TODO: this causes a segfault
     """
     def test_import_julia_modules(self):

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1,5 +1,6 @@
 import array
 import math
+import subprocess
 import unittest
 from types import ModuleType
 
@@ -93,6 +94,10 @@ class JuliaTest(unittest.TestCase):
         from julia import Main
         Main.x = x = 123456
         assert julia.eval('x') == x
+
+    def test_import_without_setup(self):
+        subprocess.check_call(
+            [sys.executable, '-c', 'from julia import Base'])
 
     #TODO: this causes a segfault
     """


### PR DESCRIPTION
@stevengj suggested to make JuliaModule lazy: https://github.com/JuliaPy/pyjulia/issues/159#issuecomment-385193887

Here is my implementation for that.  I actually added some more changes on top that to solve relevant issues.  If some components of the changes have to be removed, let me know.  Those components are implemented roughly in the following order:

### <strike>Basing on CI fix #149</strike>

<strike>
First of all this PR is based on #149 to run CI. Let me know if I need to rebase once #149 is merged.
</strike>

(Edited: now rebased)

### Lazy module member loading

`Julia.eval` is called via `JuliaModule.__getattr__` so that Julia object is brought to Python world only when it is requested.

Implemented in https://github.com/JuliaPy/pyjulia/pull/162/commits/dc40166351fd32d91668f0eacdda4a6535fc0e37 and finished by https://github.com/JuliaPy/pyjulia/pull/162/commits/843b51959a50d8cff9e07b48b1c0032408dad532

### Julia's interpreter global namespace as a module `julia.Main`

In addition to usual `JuliaModule`, the module class `JuliaMainModule` of `julia.Main` has an implementation of `__setattr__` so that you can send Python object to Julia by just setting it:

```python
>>> from julia import Main
>>> Main.xs = [1, 2, 3]
```

Since it supersede `core.Julia`, I suggest to deprecate accessing Julia values via `core.Julia().<name>`: https://github.com/JuliaPy/pyjulia/pull/162/commits/b30af4541296bfcce2f838352cd2a6f0cfe90560

### Automatically initialize Julia with `from julia import ...`

This makes `from julia import <Julia module>` works without the initial setup.  Note that a custom setup can still be done by calling `julia.Julia` with appropriate arguments *before* trying to import Julia modules:
https://github.com/JuliaPy/pyjulia/pull/162/commits/51997c0e4449d9dad330d34386d2caca1dfdbe7f

See also the document on the new API:
https://github.com/tkf/pyjulia/blob/lazy-module/README.md#usage
