### PR TITLE
remove symlink step on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,9 @@ matrix:
       - env:
           - PYTHON=python3
           - JULIA_VERSION=julianightlies
+branches:
+  only:
+    - master
 notifications:
   email: false
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,7 +70,6 @@ before_script:
 script:
   - julia -e 'Pkg.add("PyCall")'
   - julia -e 'Pkg.checkout("PyCall"); Pkg.build("PyCall")'
-  - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir())/PyCall`); Pkg.resolve()'
   - /usr/bin/python --version
   - PYTHON=${PYTHON:-python}
   - echo $PYTHON


### PR DESCRIPTION
I don't know what this line was supposed to do (it dates back ~4 years), but I can't think of any good reason to keep it, and it's breaking the tests on v0.7 (because Pkg.dir() no longer exists). 

I'm also disabling branch push builds on Travis to keep its workload reasonable. 