### PR TITLE
[WIP] Fix cross-version: ABI tag-based precompilation cache directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,9 @@ matrix:
         os: linux
       - language: python
         python: 3.5
-        env: JULIA_VERSION=juliareleases
+        env:
+          - JULIA_VERSION=juliareleases
+          - CROSS_VERSION=1
         os: linux
       - language: python
         python: 3.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,7 +65,6 @@ before_script:
   - which ${PYTHON:-python}
 script:
   - julia -e 'Pkg.add("PyCall")'
-  - julia -e 'Pkg.checkout("PyCall"); Pkg.build("PyCall")'
   - /usr/bin/python --version
   - PYTHON=${PYTHON:-python}
   - echo $PYTHON

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -70,7 +70,7 @@ build_script:
   # - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.add(\"PyCall\"); Pkg.init(); Pkg.resolve()"
   # - C:\projects\julia\bin\julia -e "using PyCall; @assert isdefined(:PyCall); @assert typeof(PyCall) === Module"
   - "SET PYTHON=%PYTHONDIR%\\python.exe"
-  - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.add(\"PyCall\"); Pkg.checkout(\"PyCall\"); Pkg.build(\"PyCall\")"
+  - C:\projects\julia\bin\julia -e "versioninfo(); Pkg.add(\"PyCall\")"
 
 test_script:
   - "SET PATH=%PYTHONDIR%;%PYTHONDIR%\\Scripts;C:\\projects\\julia\\bin;%PATH%"

--- a/julia/core.py
+++ b/julia/core.py
@@ -30,6 +30,8 @@ from ctypes import py_object
 # this is python 3.3 specific
 from types import ModuleType, FunctionType
 
+from setuptools.pep425tags import get_abi_tag
+
 #-----------------------------------------------------------------------------
 # Classes and funtions
 #-----------------------------------------------------------------------------
@@ -356,8 +358,9 @@ class Julia(object):
                 os.environ["PYCALL_LIBJULIA_PATH"] = os.path.dirname(libjulia_path)
                 # Add a private cache directory. PyCall needs a different
                 # configuration and so do any packages that depend on it.
-                self._call(u"unshift!(Base.LOAD_CACHE_PATH, abspath(Pkg.Dir._pkgroot()," +
-                    "\"lib\", \"pyjulia%s-v$(VERSION.major).$(VERSION.minor)\"))" % sys.version_info[0])
+                self._call(u"unshift!(Base.LOAD_CACHE_PATH, abspath(Pkg.Dir._pkgroot(),"
+                           "\"lib\", \"pyjulia.{}-v$(VERSION.major).$(VERSION.minor)\"))"
+                           .format(get_abi_tag()))
                 # If PyCall.ji does not exist, create an empty file to force
                 # recompilation
                 self._call(u"""


### PR DESCRIPTION
Here is an idea to fix cross-version capability of pyjulia.  How about using Python ABI tag for separating compilation cache?  In the current implementation, the cache directory uses only `sys.version_info[0]` (major version):

https://github.com/JuliaPy/pyjulia/blob/18d98e5b1b616a4d663273cc36cdd835ab0b33da/julia/core.py#L359-L360

It then doesn't work when switching between, e.g., 3.6 and 3.7.

With this patch, cache directory would be:

```console
$ ls -1 ~/.julia/lib/
pyjulia.cp36m-v0.6
pyjulia.cp37m-v0.6
v0.6
```

Though I'm actually not sure if we should use the [Python tag](https://www.python.org/dev/peps/pep-0425/#python-tag) (e.g., `cp37`) instead of the [ABI tag](https://www.python.org/dev/peps/pep-0425/#abi-tag) (e.g., `cp37m`).  Would PyCall.jl create different precompilation cache if it is build against, say, debug build and normal build?

It is WIP until we resolve:

* [ ] Merge #171 then rebase.
* [ ] Python tag vs ABI tag (see above)
* [ ] Should we "vendor" `get_abi_tag` function? https://github.com/JuliaPy/pyjulia/pull/172#discussion_r206651913

But the general idea seems to be fine; I can now use pyjulia with Python 3.6 and 3.7 with this patch.