### PR TITLE
Avoid recursion during error handling

### DIFF
--- a/julia/core.py
+++ b/julia/core.py
@@ -520,7 +520,12 @@ class Julia(object):
         self.eval("using %s" % module)
 
 
-class LegacyJulia(Julia):
+class LegacyJulia(object):
+    __doc__ = Julia.__doc__
+
+    def __init__(self, *args, **kwargs):
+        self.__julia = Julia(*args, **kwargs)
+    __init__.__doc__ = Julia.__init__.__doc__
 
     def __getattr__(self, name):
         from julia import Main
@@ -529,7 +534,10 @@ class LegacyJulia(Julia):
             " deprecated.  Use `from julia import Main; Main.<name>` or"
             " `jl = Julia(); jl.eval('<name>')`.",
             DeprecationWarning)
-        return getattr(Main, name)
+        try:
+            return getattr(self.__julia, name)
+        except AttributeError:
+            return getattr(Main, name)
 
 
 sys.meta_path.append(JuliaImporter())


### PR DESCRIPTION
In the current master, `self.sprint` and `self.showerror` are used to handle errors:

https://github.com/JuliaPy/pyjulia/blob/e617ad9c083090ffdc414d8d0d14b3b405aa1b0f/julia/core.py#L457-L476

They are set at the end of `api.Julia.__init__`

https://github.com/JuliaPy/pyjulia/blob/e617ad9c083090ffdc414d8d0d14b3b405aa1b0f/julia/core.py#L432-L433

but `self._call(u"using PyCall")` has to be called before this to initialize pyjulia in the first place:

https://github.com/JuliaPy/pyjulia/blob/e617ad9c083090ffdc414d8d0d14b3b405aa1b0f/julia/core.py#L416

The error case in `self._call(u"using PyCall")` was actually handled in `check_exception` with the `except AttributeError` branch.  However, my PR #162 just got pulled broke this horribly since accessing `self.sprint` invokes `LegacyJulia.__getattr__` which then in turn tries to initialize `api.Julia`.  There are several ways to fix it but the first thing we can do is to avoid inheritance and separate out the "magic" object `api.LegacyJulia` from the core `api.Julia`.

It fixes the error I mentioned in #175 (but not the issue itself).
