### PR TITLE
Fail with a helpful message if separate cache is not supported

### DIFF
--- a/julia/core.py
+++ b/julia/core.py
@@ -385,9 +385,12 @@ run the following commands in the Julia interpreter:
 """
 
 
-def raise_separate_cache_error(runtime, jlinfo):
+def raise_separate_cache_error(
+        runtime, jlinfo,
+        # For test:
+        _determine_if_statically_linked=determine_if_statically_linked):
     template = _separate_cache_error_common_header
-    if determine_if_statically_linked():
+    if _determine_if_statically_linked():
         template += _separate_cache_error_statically_linked
     else:
         template += _separate_cache_error_incompatible_libpython

--- a/test/test_find_libpython.py
+++ b/test/test_find_libpython.py
@@ -1,7 +1,3 @@
-"""
-Unit tests which can be done without loading `libjulia`.
-"""
-
 import platform
 
 import pytest

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -1,0 +1,42 @@
+"""
+Unit tests which can be done without loading `libjulia`.
+"""
+
+import os
+
+import pytest
+
+from julia.core import raise_separate_cache_error
+
+try:
+    from types import SimpleNamespace
+except ImportError:
+    from argparse import Namespace as SimpleNamespace  # Python 2
+
+
+def dummy_juliainfo():
+    somepath = os.devnull  # some random path
+    return SimpleNamespace(
+        pyprogramname=somepath,
+        libpython=somepath,
+    )
+
+
+def test_raise_separate_cache_error_statically_linked():
+    runtime = "julia"
+    jlinfo = dummy_juliainfo()
+    with pytest.raises(RuntimeError) as excinfo:
+        raise_separate_cache_error(
+            runtime, jlinfo,
+            _determine_if_statically_linked=lambda: True)
+    assert "is statically linked" in str(excinfo.value)
+
+
+def test_raise_separate_cache_error_dynamically_linked():
+    runtime = "julia"
+    jlinfo = dummy_juliainfo()
+    with pytest.raises(RuntimeError) as excinfo:
+        raise_separate_cache_error(
+            runtime, jlinfo,
+            _determine_if_statically_linked=lambda: False)
+    assert "have to match exactly" in str(excinfo.value)


### PR DESCRIPTION
It needs some discussion. Also, #183 has to be merged first.

With this PR, user will see error message like this which saves their time for googling the issues.

```
RuntimeError: It seems your Julia and PyJulia setup are not supported.

Julia interpreter:
    /home/takafumi/bin/julia-1.0.0
Python interpreter used by PyCall.jl:
    /home/takafumi/miniconda3/bin/python
Python interpreter used to import PyJulia.
    /usr/bin/python

In Julia >= 0.7, above two paths to the Python interpreters have to match
exactly in order for PyJulia to work.  To configure PyCall.jl to use Python
interpreter "/usr/bin/python",
run the following commands in the Julia interpreter:

    ENV["PYTHON"] = "/usr/bin/python"
    using Pkg
    Pkg.build("PyCall")

For more information, see:
    https://github.com/JuliaPy/pyjulia
    https://github.com/JuliaPy/PyCall.jl
```

I'm not 100% sure we want this.  We should probably be better just support it.  Supporting it via `DEPOT_PATH` may not be so bad (#173).

ref: #185
