### PR TITLE
Support virtualenv/venv without separate cache

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,10 +13,15 @@ environment:
     BATDIR: ci\appveyor\win32
     CROSS_VERSION: 1
 
-  # 32 julia latest Python-35
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  # 32 julia-1.0 Python-35
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/1.0/julia-1.0-latest-win32.exe"
     PYTHONDIR: "C:\\Python35"
     BATDIR: ci\appveyor\win32
+
+  # 32 julia latest Python-35
+  # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  #   PYTHONDIR: "C:\\Python35"
+  #   BATDIR: ci\appveyor\win32
 
   # 64 julia-0.6 Python-35
   - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
@@ -24,10 +29,15 @@ environment:
     BATDIR: ci\appveyor\win64
     CROSS_VERSION: 1
 
-  # 64 julia latest Python-35
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  # 64 julia-1.0 Python-35
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
     PYTHONDIR: "C:\\Python35-x64"
     BATDIR: ci\appveyor\win64
+
+  # 64 julia latest Python-35
+  # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  #   PYTHONDIR: "C:\\Python35-x64"
+  #   BATDIR: ci\appveyor\win64
 
 matrix:
   allow_failures:

--- a/julia/core.py
+++ b/julia/core.py
@@ -264,9 +264,7 @@ JuliaInfo = namedtuple(
     'JuliaInfo',
     ['JULIA_HOME', 'libjulia_path', 'image_file',
      # Variables in PyCall/deps/deps.jl:
-     'pyprogramname', 'libpython'],
-    # PyCall/deps/deps.jl may not exist; The variables are then set to None:
-    defaults=[None, None])
+     'pyprogramname', 'libpython'])
 
 
 def juliainfo(runtime='julia'):
@@ -297,6 +295,7 @@ def juliainfo(runtime='julia'):
         # object file: No such file or directory":
         env=_enviorn)
     args = output.decode("utf-8").rstrip().split("\n")
+    args.extend([None] * (len(JuliaInfo._fields) - len(args)))
     return JuliaInfo(*args)
 
 

--- a/julia/core.py
+++ b/julia/core.py
@@ -42,6 +42,12 @@ if python_version.major == 3:
 else:
     iteritems = dict.iteritems
 
+
+# As setting up Julia modifies os.environ, we need to cache it for
+# launching subprocesses later in the original environment.
+_enviorn = os.environ.copy()
+
+
 class JuliaError(Exception):
     pass
 
@@ -278,7 +284,11 @@ def juliainfo(runtime='julia'):
              include(PyCall_depsfile)
              println(pyprogramname)
          end
-         """])
+         """],
+        # Use the original environment variables to avoid a cryptic
+        # error "fake-julia/../lib/julia/sys.so: cannot open shared
+        # object file: No such file or directory":
+        env=_enviorn)
     args = output.decode("utf-8").rstrip().split("\n")
     if len(args) == 3:
         args.append(None)  # no pyprogramname set

--- a/julia/core.py
+++ b/julia/core.py
@@ -299,6 +299,12 @@ def juliainfo(runtime='julia'):
     return JuliaInfo(*args)
 
 
+def is_same_path(a, b):
+    a = os.path.realpath(os.path.normcase(a))
+    b = os.path.realpath(os.path.normcase(b))
+    return a == b
+
+
 def is_compatible_exe(jlinfo, _debug=lambda *_: None):
     """
     Determine if Python used by PyCall.jl is compatible with this Python.
@@ -322,6 +328,14 @@ def is_compatible_exe(jlinfo, _debug=lambda *_: None):
     if determine_if_statically_linked():
         _debug(sys.executable, "is statically linked.")
         return False
+
+    # Note that the following check is OK since statically linked case
+    # is already excluded.
+    if is_same_path(jlinfo.pyprogramname, sys.executable):
+        # In macOS and Windows, find_libpython does not work as good
+        # as in Linux.  We add this shortcut so that PyJulia can work
+        # in those environments.
+        return True
 
     py_libpython = find_libpython()
     jl_libpython = normalize_path(jlinfo.libpython)

--- a/julia/core.py
+++ b/julia/core.py
@@ -299,7 +299,7 @@ def juliainfo(runtime='julia'):
     return JuliaInfo(*args)
 
 
-def is_compatible_exe(jlinfo):
+def is_compatible_exe(jlinfo, _debug=lambda *_: None):
     """
     Determine if Python used by PyCall.jl is compatible with this Python.
 
@@ -315,12 +315,18 @@ def is_compatible_exe(jlinfo):
         A `JuliaInfo` object returned by `juliainfo` function.
     """
     if jlinfo.libpython is None:
+        _debug("libpython cannot be read from PyCall/deps/deps.jl")
         return False
 
     if determine_if_statically_linked():
+        _debug(sys.executable, "is statically linked.")
         return False
 
-    return find_libpython() == normalize_path(jlinfo.libpython)
+    py_libpython = find_libpython()
+    jl_libpython = normalize_path(jlinfo.libpython)
+    _debug("py_libpython =", py_libpython)
+    _debug("jl_libpython =", jl_libpython)
+    return py_libpython == jl_libpython
 
 
 _julia_runtime = [False]
@@ -396,7 +402,7 @@ class Julia(object):
                 else:
                     jl_init_path = JULIA_HOME.encode("utf-8") # initialize with JULIA_HOME
 
-            use_separate_cache = not is_compatible_exe(jlinfo)
+            use_separate_cache = not is_compatible_exe(jlinfo, _debug=self._debug)
             self._debug("use_separate_cache =", use_separate_cache)
             if use_separate_cache:
                 PYCALL_JULIA_HOME = os.path.join(

--- a/julia/core.py
+++ b/julia/core.py
@@ -314,6 +314,7 @@ def is_compatible_exe(jlinfo, _debug=lambda *_: None):
     jlinfo : JuliaInfo
         A `JuliaInfo` object returned by `juliainfo` function.
     """
+    _debug("jlinfo.libpython =", jlinfo.libpython)
     if jlinfo.libpython is None:
         _debug("libpython cannot be read from PyCall/deps/deps.jl")
         return False

--- a/julia/find_libpython.py
+++ b/julia/find_libpython.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python
+
+"""
+Locate libpython associated with this Python executable.
+"""
+
+from __future__ import print_function
+
+from logging import getLogger
+import ctypes.util
+import os
+import platform
+import sys
+import sysconfig
+
+logger = getLogger("find_libpython")
+
+SHLIB_SUFFIX = sysconfig.get_config_var("SHLIB_SUFFIX") or ".so"
+
+
+def library_name(name, suffix=SHLIB_SUFFIX,
+                 is_windows=platform.system() == "Windows"):
+    """
+    Convert a file basename `name` to a library name (no "lib" and ".so" etc.)
+
+    >>> library_name("libpython3.7m.so")                   # doctest: +SKIP
+    'python3.7m'
+    >>> library_name("libpython3.7m.so", suffix=".so", is_windows=False)
+    'python3.7m'
+    >>> library_name("libpython3.7m.dylib", suffix=".dylib", is_windows=False)
+    'python3.7m'
+    >>> library_name("python37.dll", suffix=".dll", is_windows=True)
+    'python37'
+    """
+    if not is_windows:
+        name = name[len("lib"):]
+    if suffix and name.endswith(suffix):
+        name = name[:-len(suffix)]
+    return name
+
+
+def append_truthy(list, item):
+    if item:
+        list.append(item)
+
+
+def libpython_candidates(suffix=SHLIB_SUFFIX):
+    """
+    Iterate over candidate paths of libpython.
+
+    Yields
+    ------
+    path : str or None
+        Candidate path to libpython.  The path may not be a fullpath
+        and may not exist.
+    """
+    is_windows = platform.system() == "Windows"
+
+    # List candidates for libpython basenames
+    lib_basenames = []
+    append_truthy(lib_basenames, sysconfig.get_config_var("LDLIBRARY"))
+
+    LIBRARY = sysconfig.get_config_var("LIBRARY")
+    if LIBRARY:
+        lib_basenames.append(os.path.splitext(LIBRARY)[0] + suffix)
+
+    dlprefix = "" if is_windows else "lib"
+    sysdata = dict(
+        v=sys.version_info,
+        abiflags=(sysconfig.get_config_var("ABIFLAGS") or
+                  sysconfig.get_config_var("abiflags") or ""),
+    )
+    lib_basenames.extend(dlprefix + p + suffix for p in [
+        "python{v.major}.{v.minor}{abiflags}".format(**sysdata),
+        "python{v.major}.{v.minor}".format(**sysdata),
+        "python{v.major}".format(**sysdata),
+        "python",
+    ])
+
+    # List candidates for directories in which libpython may exist
+    lib_dirs = []
+    append_truthy(lib_dirs, sysconfig.get_config_var("LIBDIR"))
+
+    if is_windows:
+        lib_dirs.append(os.path.join(os.path.dirname(sys.executable)))
+    else:
+        lib_dirs.append(os.path.join(
+            os.path.dirname(os.path.dirname(sys.executable)),
+            "lib"))
+
+    # For macOS:
+    append_truthy(lib_dirs, sysconfig.get_config_var("PYTHONFRAMEWORKPREFIX"))
+
+    lib_dirs.append(sys.exec_prefix)
+    lib_dirs.append(os.path.join(sys.exec_prefix, "lib"))
+
+    for directory in lib_dirs:
+        for basename in lib_basenames:
+            yield os.path.join(directory, basename)
+
+    # In macOS and Windows, ctypes.util.find_library returns a full path:
+    for basename in lib_basenames:
+        yield ctypes.util.find_library(library_name(basename))
+
+
+def normalize_path(path, suffix=SHLIB_SUFFIX):
+    """
+    Normalize shared library `path` to a real path.
+
+    If `path` is not a full path, `None` is returned.  If `path` does
+    not exists, append `SHLIB_SUFFIX` and check if it exists.
+    Finally, the path is canonicalized by following the symlinks.
+
+    Parameters
+    ----------
+    path : str ot None
+        A candidate path to a shared library.
+    """
+    if not path:
+        return None
+    if not os.path.isabs(path):
+        return None
+    if os.path.exists(path):
+        return os.path.realpath(path)
+    if os.path.exists(path + suffix):
+        return os.path.realpath(path + suffix)
+    return None
+
+
+def finding_libpython():
+    """
+    Iterate over existing libpython paths.
+
+    The first item is likely to be the best one.  It may yield
+    duplicated paths.
+
+    Yields
+    ------
+    path : str
+        Existing path to a libpython.
+    """
+    for path in libpython_candidates():
+        logger.debug("Candidate: %s", path)
+        normalized = normalize_path(path)
+        logger.debug("Normalized: %s", normalized)
+        if normalized:
+            logger.debug("Found: %s", normalized)
+            yield normalized
+
+
+def find_libpython():
+    """
+    Return a path (`str`) to libpython or `None` if not found.
+
+    Parameters
+    ----------
+    path : str or None
+        Existing path to the (supposedly) correct libpython.
+    """
+    for path in finding_libpython():
+        return os.path.realpath(path)
+
+
+def cli_find_libpython(verbose, list_all):
+    import logging
+    # Importing `logging` module here so that using `logging.debug`
+    # instead of `logger.debug` outside of this function becomes an
+    # error.
+
+    if verbose:
+        logging.basicConfig(level=logging.DEBUG)
+
+    if list_all:
+        for path in finding_libpython():
+            print(path)
+        return
+
+    path = find_libpython()
+    if path is None:
+        return 1
+    print(path, end="")
+
+
+def main(args=None):
+    import argparse
+    parser = argparse.ArgumentParser(
+        description=__doc__)
+    parser.add_argument(
+        "--verbose", "-v", action="store_true",
+        help="Print debugging information.")
+    parser.add_argument(
+        "--list-all", action="store_true",
+        help="Print list of all paths found.")
+    ns = parser.parse_args(args)
+    parser.exit(cli_find_libpython(**vars(ns)))
+
+
+if __name__ == "__main__":
+    main()

--- a/julia/find_libpython.py
+++ b/julia/find_libpython.py
@@ -9,17 +9,19 @@ from __future__ import print_function, absolute_import
 from logging import getLogger
 import ctypes.util
 import os
-import platform
 import sys
 import sysconfig
 
 logger = getLogger("find_libpython")
 
+is_windows = os.name == "nt"
+is_apple = sys.platform == "darwin"
+
 SHLIB_SUFFIX = sysconfig.get_config_var("SHLIB_SUFFIX")
 if SHLIB_SUFFIX is None:
-    if platform.system() == "Windows":
+    if is_windows:
         SHLIB_SUFFIX = ".dll"
-    elif platform.system() == "Darwin":
+    elif is_apple:
         SHLIB_SUFFIX = ".dylib"
     else:
         SHLIB_SUFFIX = ".so"
@@ -36,7 +38,7 @@ def linked_libpython():
     path : str or None
         A path to linked libpython.  Return `None` if statically linked.
     """
-    if platform.system() == "Windows":
+    if is_windows:
         return None
     return _linked_libpython_unix()
 
@@ -67,8 +69,7 @@ def _linked_libpython_unix():
     return path
 
 
-def library_name(name, suffix=SHLIB_SUFFIX,
-                 is_windows=platform.system() == "Windows"):
+def library_name(name, suffix=SHLIB_SUFFIX, is_windows=is_windows):
     """
     Convert a file basename `name` to a library name (no "lib" and ".so" etc.)
 
@@ -105,8 +106,6 @@ def libpython_candidates(suffix=SHLIB_SUFFIX):
     """
 
     yield linked_libpython()
-
-    is_windows = platform.system() == "Windows"
 
     # List candidates for libpython basenames
     lib_basenames = []
@@ -194,6 +193,8 @@ def finding_libpython():
     path : str
         Existing path to a libpython.
     """
+    logger.debug("is_windows = %s", is_windows)
+    logger.debug("is_apple = %s", is_apple)
     for path in libpython_candidates():
         logger.debug("Candidate: %s", path)
         normalized = normalize_path(path)

--- a/julia/find_libpython.py
+++ b/julia/find_libpython.py
@@ -119,12 +119,15 @@ def libpython_candidates(suffix=SHLIB_SUFFIX):
     dlprefix = "" if is_windows else "lib"
     sysdata = dict(
         v=sys.version_info,
-        abiflags=(sysconfig.get_config_var("ABIFLAGS") or
+        # VERSION is X.Y in Linux/macOS and XY in Windows:
+        VERSION=(sysconfig.get_config_var("VERSION") or
+                 "{v.major}.{v.minor}".format(v=sys.version_info)),
+        ABIFLAGS=(sysconfig.get_config_var("ABIFLAGS") or
                   sysconfig.get_config_var("abiflags") or ""),
     )
     lib_basenames.extend(dlprefix + p + suffix for p in [
-        "python{v.major}.{v.minor}{abiflags}".format(**sysdata),
-        "python{v.major}.{v.minor}".format(**sysdata),
+        "python{VERSION}{ABIFLAGS}".format(**sysdata),
+        "python{VERSION}".format(**sysdata),
         "python{v.major}".format(**sysdata),
         "python",
     ])

--- a/julia/find_libpython.py
+++ b/julia/find_libpython.py
@@ -15,7 +15,14 @@ import sysconfig
 
 logger = getLogger("find_libpython")
 
-SHLIB_SUFFIX = sysconfig.get_config_var("SHLIB_SUFFIX") or ".so"
+SHLIB_SUFFIX = sysconfig.get_config_var("SHLIB_SUFFIX")
+if SHLIB_SUFFIX is None:
+    if platform.system() == "Windows":
+        SHLIB_SUFFIX = ".dll"
+    elif platform.system() == "Darwin":
+        SHLIB_SUFFIX = ".dylib"
+    else:
+        SHLIB_SUFFIX = ".so"
 
 
 def linked_libpython():

--- a/julia/find_libpython.py
+++ b/julia/find_libpython.py
@@ -4,7 +4,7 @@
 Locate libpython associated with this Python executable.
 """
 
-from __future__ import print_function
+from __future__ import print_function, absolute_import
 
 from logging import getLogger
 import ctypes.util

--- a/julia/with_rebuilt.py
+++ b/julia/with_rebuilt.py
@@ -27,6 +27,16 @@ def maybe_rebuild(rebuild, julia):
             using Pkg
         end
         Pkg.build("PyCall")
+        if VERSION < v"0.7.0"
+            pkgdir = Pkg.dir("PyCall")
+        else
+            modpath = Base.locate_package(Base.identify_package("PyCall"))
+            pkgdir = joinpath(dirname(modpath), "..")
+        end
+        logfile = joinpath(pkgdir, "deps", "build.log")
+        if isfile(logfile)
+            print(read(logfile, String))
+        end
         """]
         print('Building PyCall.jl with PYTHON =', sys.executable)
         print(*build)

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -5,6 +5,8 @@ Unit tests which can be done without loading `libjulia`.
 from julia.find_libpython import finding_libpython
 
 
-def test_smoke_finding_libpython():
+def test_finding_libpython_yield_type():
     paths = list(finding_libpython())
-    assert set(map(type, paths)) == {str}
+    assert set(map(type, paths)) <= {str}
+# In a statically linked Python executable, no paths may be found.  So
+# let's just check returned type of finding_libpython.

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,11 +2,28 @@
 Unit tests which can be done without loading `libjulia`.
 """
 
-from julia.find_libpython import finding_libpython
+import platform
+
+import pytest
+
+from julia.find_libpython import finding_libpython, linked_libpython
+from julia.core import determine_if_statically_linked
+
+try:
+    unicode
+except NameError:
+    unicode = str  # for Python 3
 
 
 def test_finding_libpython_yield_type():
     paths = list(finding_libpython())
-    assert set(map(type, paths)) <= {str}
+    assert set(map(type, paths)) <= {str, unicode}
 # In a statically linked Python executable, no paths may be found.  So
 # let's just check returned type of finding_libpython.
+
+
+@pytest.mark.xfail(platform.system() == "Windows",
+                   reason="linked_libpython is not implemented for Windows")
+def test_linked_libpython():
+    if determine_if_statically_linked():
+        assert linked_libpython() is not None

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -2,17 +2,9 @@
 Unit tests which can be done without loading `libjulia`.
 """
 
-import sys
-
-import pytest
-
-from julia.core import is_different_exe
+from julia.find_libpython import finding_libpython
 
 
-@pytest.mark.parametrize('pyprogramname, sys_executable, exe_differs', [
-    (sys.executable, sys.executable, False),
-    (None, sys.executable, True),
-    ('/dev/null', sys.executable, True),
-])
-def test_is_different_exe(pyprogramname, sys_executable, exe_differs):
-    assert is_different_exe(pyprogramname, sys_executable) == exe_differs
+def test_smoke_finding_libpython():
+    paths = list(finding_libpython())
+    assert set(map(type, paths)) == {str}

--- a/tox.ini
+++ b/tox.ini
@@ -27,3 +27,9 @@ passenv =
     # See: https://coveralls-python.readthedocs.io/en/latest/usage/tox.html#travisci
     TRAVIS
     TRAVIS_*
+
+[pytest]
+addopts =
+    --doctest-modules
+    --ignore=julia/fake-julia
+    --ignore=test/_star_import.py

--- a/tox.ini
+++ b/tox.ini
@@ -12,6 +12,10 @@ deps =
     ipython
     mock
 commands =
+    python -m julia.find_libpython --list-all --verbose
+    # Print libpython candidates found by `find_libpython`.  It may be
+    # useful for debugging.
+
     python -m julia.with_rebuilt -- python -m pytest {posargs}
     # Using "python -m pytest" to exactly match the Python interpreter
     # used to build PyCall.jl via julia/with_rebuilt.py (when

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,10 @@ envlist = py27, py36
 
 [testenv]
 deps =
-    pytest
+    pytest != 3.7.3
+    # Don't install 3.7.3 to avoid doctest failures in macOS
+    # https://github.com/pytest-dev/pytest/pull/3893#issuecomment-416560866
+
     pytest-cov
     numpy
     ipython


### PR DESCRIPTION
(To be rebased after #188)

With this patch, we should be able to have multiple Python virtual environments without duplicating Julia's precompilation cache, provided that those Python executables are linked against same libpython.

Since PyCall.jl only cares about the identity of libpython when it is already initialized https://github.com/JuliaPy/pyjulia/issues/182#issuecomment-413341399, i.e., it does [not](https://github.com/JuliaPy/PyCall.jl/blob/f1a63572df9ebe7c8908674e6ade596de495fe73/src/pyinit.jl#L79-L89) call `Py_SetPythonHome` etc., I think we only need to compare the path to libpython.

@stevengj Is it correct?  It seems that it works in my laptop.
