### PR TITLE
Improve juliainfo

### DIFF
--- a/julia/core.py
+++ b/julia/core.py
@@ -274,7 +274,7 @@ def juliainfo(runtime='julia', **popen_kwargs):
     popen_kwargs.setdefault("env", _enviorn)
 
     proc = subprocess.Popen(
-        [runtime, "-e",
+        [runtime, "--startup-file=no", "-e",
          """
          println(VERSION < v"0.7.0-DEV.3073" ? JULIA_HOME : Base.Sys.BINDIR)
          if VERSION >= v"0.7.0-DEV.3630"

--- a/julia/core.py
+++ b/julia/core.py
@@ -267,7 +267,12 @@ JuliaInfo = namedtuple(
      'pyprogramname', 'libpython'])
 
 
-def juliainfo(runtime='julia'):
+def juliainfo(runtime='julia', **popen_kwargs):
+    # Use the original environment variables to avoid a cryptic
+    # error "fake-julia/../lib/julia/sys.so: cannot open shared
+    # object file: No such file or directory":
+    popen_kwargs.setdefault("env", _enviorn)
+
     output = subprocess.check_output(
         [runtime, "-e",
          """
@@ -282,7 +287,11 @@ def juliainfo(runtime='julia'):
              PyCall_depsfile = Pkg.dir("PyCall","deps","deps.jl")
          else
              modpath = Base.locate_package(Base.identify_package("PyCall"))
-             PyCall_depsfile = joinpath(dirname(modpath),"..","deps","deps.jl")
+             if modpath == nothing
+                 PyCall_depsfile = nothing
+             else
+                 PyCall_depsfile = joinpath(dirname(modpath),"..","deps","deps.jl")
+             end
          end
          if PyCall_depsfile !== nothing && isfile(PyCall_depsfile)
              include(PyCall_depsfile)
@@ -290,10 +299,7 @@ def juliainfo(runtime='julia'):
              println(libpython)
          end
          """],
-        # Use the original environment variables to avoid a cryptic
-        # error "fake-julia/../lib/julia/sys.so: cannot open shared
-        # object file: No such file or directory":
-        env=_enviorn)
+        **popen_kwargs)
     args = output.decode("utf-8").rstrip().split("\n")
     args.extend([None] * (len(JuliaInfo._fields) - len(args)))
     return JuliaInfo(*args)

--- a/test/test_juliainfo.py
+++ b/test/test_juliainfo.py
@@ -1,0 +1,42 @@
+import os
+import subprocess
+
+from julia.core import juliainfo, _enviorn
+
+
+def check_core_juliainfo(jlinfo):
+    assert os.path.exists(jlinfo.JULIA_HOME)
+    assert os.path.exists(jlinfo.libjulia_path)
+    assert os.path.exists(jlinfo.image_file)
+
+
+def test_juliainfo_normal():
+    jlinfo = juliainfo(os.getenv("JULIA_EXE", "julia"))
+    check_core_juliainfo(jlinfo)
+    assert os.path.exists(jlinfo.pyprogramname)
+    # Note: jlinfo.libpython is probably not a full path so we are not
+    # testing it here.
+
+
+def test_juliainfo_without_pycall(tmpdir):
+    """
+    `juliainfo` should not fail even when PyCall.jl is not installed.
+    """
+
+    runtime = os.getenv("JULIA_EXE", "julia")
+
+    JULIA_DEPOT_PATH = subprocess.check_output(
+        [runtime, "-e", """
+        paths = [ARGS[1], DEPOT_PATH[2:end]...]
+        print(join(paths, Sys.iswindows() ? ';' : ':'))
+        """, str(tmpdir)],
+        env=_enviorn,
+        universal_newlines=True)
+
+    jlinfo = juliainfo(
+        runtime,
+        env=dict(_enviorn, JULIA_DEPOT_PATH=JULIA_DEPOT_PATH))
+
+    check_core_juliainfo(jlinfo)
+    assert jlinfo.pyprogramname is None
+    assert jlinfo.libpython is None


### PR DESCRIPTION
Improvements:

* The original environment variables are used when launching `juliainfo`.  This makes it possible to call `juliainfo` after setting up `core.Julia`.  This should not happen when using `core.Julia` normally.  However, some bugs may invoke `juliainfo` after libjulia initialization.  This PR does not fix such bug but at least make the error message less insane.

* Make `juliainfo` callable even when PyCall.jl is not installed.  This makes the failure less confusing; i.e., PyJulia fails when `using PyCall` is evaluated.

* The standard error of julia is captured.  It is bundled in CalledProcessError in case of non-zero exit code.  In case of zero exit code, stderr emits warning if some message was written by julia.

* Currently, startup file is not loaded in the main PyJulia session. Including the startup file has some potential problem.  For example, if something is printed in the startup file then `juliainfo` would break.  So it seems to be that the safe default is to avoid loading the startup file (though it makes sense to add an option to load it in the future).
