### PR TITLE
Add python-jl CLI

### DIFF
--- a/julia/core.py
+++ b/julia/core.py
@@ -399,7 +399,14 @@ For more information, see:
 _separate_cache_error_statically_linked = """
 Your Python interpreter "{sys.executable}"
 is statically linked to libpython.  Currently, PyJulia does not support
-such Python interpreter.  For available workarounds, see:
+such Python interpreter.  One easy workaround is to run your Python
+script with `python-jl` command bundled in PyJulia.  You can simply do:
+
+    python-jl PATH/TO/YOUR/SCRIPT.py
+
+See `python-jl --help` for more information.
+
+For other available workarounds, see:
     https://github.com/JuliaPy/pyjulia/issues/185
 """
 

--- a/julia/core.py
+++ b/julia/core.py
@@ -686,6 +686,10 @@ class Julia(object):
         self.sprint = self.eval('sprint')
         self.showerror = self.eval('showerror')
 
+        if self.eval('VERSION >= v"0.7-"'):
+            self.eval("@eval Main import Base.MainInclude: eval, include")
+            # https://github.com/JuliaLang/julia/issues/28825
+
     def _debug(self, *msg):
         """
         Print some debugging stuff, if enabled

--- a/julia/core.py
+++ b/julia/core.py
@@ -569,7 +569,7 @@ class Julia(object):
         else:
             # we're assuming here we're fully inside a running Julia process,
             # so we're fishing for symbols in our own process table
-            self.api = ctypes.PyDLL('')
+            self.api = ctypes.PyDLL(None)
 
         # Store the running interpreter reference so we can start using it via self.call
         self.api.jl_.argtypes = [void_p]

--- a/julia/core.py
+++ b/julia/core.py
@@ -140,7 +140,7 @@ class JuliaMainModule(JuliaModule):
             juliapath = remove_prefix(self.__name__, "julia.")
             setter = '''
             PyCall.pyfunctionret(
-                (x) -> eval({}, :({} = $x)),
+                (x) -> Base.eval({}, :({} = $x)),
                 Any,
                 PyCall.PyAny)
             '''.format(juliapath, jl_name(name))

--- a/julia/pseudo_python_cli.py
+++ b/julia/pseudo_python_cli.py
@@ -7,19 +7,43 @@ https://docs.python.org/3/using/cmdline.html
 
 from __future__ import print_function, absolute_import
 
-import argparse
+from collections import namedtuple
 import code
+import copy
 import runpy
 import sys
 import traceback
+
+try:
+    from types import SimpleNamespace
+except ImportError:
+    from argparse import Namespace as SimpleNamespace
+
+
+ARGUMENT_HELP = """
+positional arguments:
+  script         path to file (default: None)
+  args           arguments passed to program in sys.argv[1:]
+
+optional arguments:
+  -h, --help     show this help message and exit
+  -i             inspect interactively after running script.
+  --version, -V  Print the Python version number and exit.
+                 -VV is not supported.
+  -c COMMAND     Execute the Python code in COMMAND.
+  -m MODULE      Search sys.path for the named MODULE and execute its contents
+                 as the __main__ module.
+"""
 
 
 def python(module, command, script, args, interactive):
     if command:
         sys.argv[0] = "-c"
-    elif script:
-        sys.argv[0] = script
+
+    assert sys.argv
     sys.argv[1:] = args
+    if script:
+        sys.argv[0] = script
 
     banner = ""
     try:
@@ -50,93 +74,221 @@ def python(module, command, script, args, interactive):
     if interactive:
         code.interact(banner=banner, local=scope)
 
+ArgDest = namedtuple("ArgDest", "dest names default")
+Optional = namedtuple("Optional", "name is_long argdest nargs action terminal")
+Result = namedtuple("Result", "option values")
 
-class CustomFormatter(argparse.RawDescriptionHelpFormatter,
-                      argparse.ArgumentDefaultsHelpFormatter):
-    pass
+
+class PyArgumentParser(object):
+
+    """
+    `ArgumentParser`-like parser with "terminal option" support.
+
+    Major differences:
+
+    * Formatted help has to be provided to `description`.
+    * Many options for `.add_argument` are not supported.
+    * Especially, there is no positional argument support: all positional
+      arguments go into `ns.args`.
+    * `.add_argument` can take boolean option `terminal` (default: `False`)
+      to stop parsing after consuming the given option.
+    """
+
+    def __init__(self, prog=None, usage="%(prog)s [options] [args]",
+                 description=""):
+        self.prog = sys.argv[0] if prog is None else prog
+        self.usage = usage
+        self.description = description
+
+        self._dests = ["args"]
+        self._argdests = [ArgDest("args", (), [])]
+        self._options = []
+
+        self.add_argument("--help", "-h", "-?", action="store_true")
+
+    def format_usage(self):
+        return "usage: " + self.usage % {"prog": self.prog}
+
+    # Once we drop Python 2, we can do:
+    """
+    def add_argument(self, name, *alt, dest=None, nargs=None, action=None,
+                     default=None, terminal=False):
+    """
+
+    def add_argument(self, name, *alt, **kwargs):
+        return self._add_argument_impl(name, alt, **kwargs)
+
+    def _add_argument_impl(self, name, alt, dest=None, nargs=None, action=None,
+                           default=None, terminal=False):
+        if dest is None:
+            if name.startswith("--"):
+                dest = name[2:]
+            elif not name.startswith("-"):
+                dest = name
+            else:
+                raise ValueError(name)
+
+        if not name.startswith("-"):
+            raise NotImplementedError(
+                "Positional arguments are not supported."
+                " All positional arguments will be stored in `ns.args`.")
+        if terminal and action is not None:
+            raise NotImplementedError("Terminal option has to have argument.")
+
+        if nargs is not None and action is not None:
+            raise TypeError("`nargs` and `action` are mutually exclusive")
+        if action == "store_true":
+            nargs = 0
+        if nargs is None:
+            nargs = 1
+        assert isinstance(nargs, int)
+        assert action in (None, "store_true")
+
+        assert dest not in self._dests
+        self._dests.append(dest)
+
+        argdest = ArgDest(
+            dest=dest,
+            names=(name,) + alt,
+            default=default,
+        )
+        self._argdests.append(argdest)
+
+        for arg in (name,) + alt:
+            self._options.append(Optional(
+                name=arg,
+                is_long=arg.startswith("--"),
+                argdest=argdest,
+                nargs=nargs,
+                action=action,
+                terminal=terminal,
+            ))
+
+    def parse_args(self, args):
+        ns = SimpleNamespace(**{
+            argdest.dest: copy.copy(argdest.default)
+            for argdest in self._argdests
+        })
+        args_iter = iter(args)
+        self._parse_until_terminal(ns, args_iter)
+        ns.args.extend(args_iter)
+
+        if ns.help:
+            self.print_help()
+            self.exit()
+        del ns.help
+
+        return ns
+
+    def _parse_until_terminal(self, ns, args_iter):
+        seen = set()
+        for a in args_iter:
+
+            results = self._find_matches(a)
+            if not results:
+                ns.args.append(a)
+                break
+
+            for i, res in enumerate(results):
+                dest = res.option.argdest.dest
+                if dest in seen:
+                    self._usage_and_error(
+                        "{} provided more than twice"
+                        .format(" ".join(res.option.argdest.names)))
+                seen.add(dest)
+
+                while len(res.values) < res.option.nargs:
+                    try:
+                        res.values.append(next(args_iter))
+                    except StopIteration:
+                        self.error(self.format_usage())
+
+                if res.option.action == "store_true":
+                    setattr(ns, dest, True)
+                else:
+                    value = res.values
+                    if res.option.nargs == 1:
+                        value, = value
+                    setattr(ns, dest, value)
+
+                if res.option.terminal:
+                    assert i == len(results) - 1
+                    return
+
+    def _find_matches(self, arg):
+        for opt in self._options:
+            if arg == opt.name:
+                return [Result(opt, [])]
+            elif arg.startswith(opt.name):
+                # i.e., len(arg) > len(opt.name):
+                if opt.is_long and arg[len(opt.name)] == "=":
+                    return [Result(opt, [arg[len(opt.name) + 1:]])]
+                elif not opt.is_long:
+                    if opt.nargs > 0:
+                        return [Result(opt, [arg[len(opt.name):]])]
+                    else:
+                        results = [Result(opt, [])]
+                        rest = "-" + arg[len(opt.name):]
+                        results.extend(self._find_matches(rest))
+                        return results
+                        # arg="-ih" -> rest="-h"
+        return []
+
+    def print_usage(self, file=None):
+        print(self.format_usage(), file=file or sys.stdout)
+
+    def print_help(self):
+        self.print_usage()
+        print()
+        print(self.description)
+
+    def exit(self, status=0):
+        sys.exit(status)
+
+    def _usage_and_error(self, message):
+        self.print_usage(sys.stderr)
+        print(file=sys.stderr)
+        self.error(message)
+
+    def error(self, message):
+        print(message, file=sys.stderr)
+        self.exit(2)
 
 
-def make_parser(description=__doc__):
-    parser = argparse.ArgumentParser(
+def make_parser(description=__doc__ + ARGUMENT_HELP):
+    parser = PyArgumentParser(
         prog=None if sys.argv[0] else "python",
         usage="%(prog)s [option] ... [-c cmd | -m mod | script | -] [args]",
-        formatter_class=CustomFormatter,
         description=description)
 
-    parser.add_argument(
-        "-i", dest="interactive", action="store_true",
-        help="""
-        inspect interactively after running script.
-        """)
-    parser.add_argument(
-        "--version", "-V", action="version",
-        version="Python {0}.{1}.{2}".format(*sys.version_info),
-        help="""
-        print the Python version number and exit.
-        -VV is not supported.
-        """)
-
-    group = parser.add_mutually_exclusive_group()
-    group.add_argument(
-        "-c", dest="command",
-        help="""
-        Execute the Python code in COMMAND.
-        """)
-    group.add_argument(
-        "-m", dest="module",
-        help="""
-        Search sys.path for the named MODULE and execute its contents
-        as the __main__ module.
-        """)
-
-    parser.add_argument(
-        "script", nargs="?",
-        help="path to file")
-    parser.add_argument(
-        "args", nargs=argparse.REMAINDER,
-        help="arguments passed to program in sys.argv[1:]")
+    parser.add_argument("-i", dest="interactive", action="store_true")
+    parser.add_argument("--version", "-V", action="store_true")
+    parser.add_argument("-c", dest="command", terminal=True)
+    parser.add_argument("-m", dest="module", terminal=True)
 
     return parser
 
 
 def parse_args_with(parser, args):
-    ns = parser.parse_args(list(preprocess_args(args)))
-    if (ns.command or ns.module) and ns.script:
-        ns.args = [ns.script] + ns.args
-        ns.script = None
+    ns = parser.parse_args(args)
+
+    if ns.command and ns.module:
+        parser.error("-c and -m are mutually exclusive")
+    if ns.version:
+        print("Python {0}.{1}.{2}".format(*sys.version_info))
+        parser.exit()
+    del ns.version
+
+    ns.script = None
+    if (not (ns.command or ns.module)) and ns.args:
+        ns.script = ns.args[0]
+        ns.args = ns.args[1:]
+
     return ns
 
 
 def parse_args(args):
     return parse_args_with(make_parser(), args)
-
-
-def preprocess_args(args):
-    """
-    Insert "--" after "[-c cmd | -m mod | script | -]"
-
-    This is required for the following to work:
-
-    >>> ns = parse_args(["-mjson.tool", "-h"])
-    >>> ns.args
-    ['-h']
-    """
-    it = iter(args)
-    for a in it:
-        yield a
-
-        if a in ("-m", "-c"):
-            try:
-                yield next(it)
-            except StopIteration:
-                return
-            yield "--"
-        elif a == "-":
-            yield "--"
-        elif a.startswith("-"):
-            if a[1] in ("m", "c"):
-                yield "--"
-            # otherwise, it's some
 
 
 def main(args=None):

--- a/julia/pseudo_python_cli.py
+++ b/julia/pseudo_python_cli.py
@@ -5,6 +5,8 @@ It tries to mimic a subset of Python CLI:
 https://docs.python.org/3/using/cmdline.html
 """
 
+from __future__ import print_function, absolute_import
+
 import argparse
 import code
 import runpy

--- a/julia/pseudo_python_cli.py
+++ b/julia/pseudo_python_cli.py
@@ -1,0 +1,154 @@
+"""
+Pseudo Python command line interface.
+
+It tries to mimic a subset of Python CLI:
+https://docs.python.org/3/using/cmdline.html
+"""
+
+import argparse
+import code
+import runpy
+import sys
+import traceback
+
+
+def python(module, command, script, script_args, interactive):
+    if command:
+        sys.argv[0] = "-c"
+    elif script:
+        sys.argv[0] = script
+    sys.argv[1:] = script_args
+
+    banner = ""
+    try:
+        if command:
+            scope = {}
+            exec(command, scope)
+        elif module:
+            scope = runpy.run_module(
+                module,
+                run_name="__main__",
+                alter_sys=True)
+        elif script == "-":
+            source = sys.stdin.read()
+            exec(compile(source, "<stdin>", "exec"), scope)
+        elif script:
+            scope = runpy.run_path(
+                script,
+                run_name="__main__")
+        else:
+            interactive = True
+            scope = None
+            banner = None  # show banner
+    except Exception:
+        if not interactive:
+            raise
+        traceback.print_exc()
+
+    if interactive:
+        code.interact(banner=banner, local=scope)
+
+
+class CustomFormatter(argparse.RawDescriptionHelpFormatter,
+                      argparse.ArgumentDefaultsHelpFormatter):
+    pass
+
+
+def make_parser(description=__doc__):
+    parser = argparse.ArgumentParser(
+        prog=None if sys.argv[0] else "python",
+        usage="%(prog)s [option] ... [-c cmd | -m mod | script | -] [args]",
+        formatter_class=CustomFormatter,
+        description=description)
+
+    parser.add_argument(
+        "-i", dest="interactive", action="store_true",
+        help="""
+        inspect interactively after running script.
+        """)
+    parser.add_argument(
+        "--version", "-V", action="version",
+        version="Python {0}.{1}.{2}".format(*sys.version_info),
+        help="""
+        print the Python version number and exit.
+        -VV is not supported.
+        """)
+
+    group = parser.add_mutually_exclusive_group()
+    group.add_argument(
+        "-c", dest="command",
+        help="""
+        Execute the Python code in COMMAND.
+        """)
+    group.add_argument(
+        "-m", dest="module",
+        help="""
+        Search sys.path for the named MODULE and execute its contents
+        as the __main__ module.
+        """)
+
+    parser.add_argument(
+        "script", nargs="?",
+        help="path to file")
+
+    return parser
+
+
+def split_args(args):
+    """
+    Split arguments to Python and `sys.argv[1:]` to be used inside "script".
+
+    >>> split_args(["-i", "script.py", "arg"])
+    (['-i', 'script.py'], ['arg'])
+    >>> split_args(["-c", "1/0"])
+    (['-c', '1/0'], [])
+    >>> split_args(["-mjson.tool", "-h"])
+    (['-mjson.tool'], ['-h'])
+    """
+    it = iter(args)
+    py_args = []
+    for a in it:
+        if a in ("-c", "-m"):
+            py_args.append(a)
+            try:
+                a = next(it)
+            except StopIteration:
+                break
+            py_args.append(a)
+            break
+        elif a == "-":
+            py_args.append(a)
+            break
+        elif a.startswith("-"):
+            py_args.append(a)
+            if a[1] in ("c", "m"):
+                break
+        else:  # script
+            py_args.append(a)
+            break
+    return py_args, list(it)
+
+
+def parse_args(args):
+    parser = make_parser()
+    py_args, script_args = split_args(args)
+    ns = parser.parse_args(py_args)
+    ns.script_args = script_args
+    return ns
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    try:
+        ns = parse_args(args)
+        python(**vars(ns))
+    except SystemExit as err:
+        return err.code
+    except Exception:
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/julia/pseudo_python_cli.py
+++ b/julia/pseudo_python_cli.py
@@ -133,7 +133,9 @@ class PyArgumentParser(object):
                 "Positional arguments are not supported."
                 " All positional arguments will be stored in `ns.args`.")
         if terminal and action is not None:
-            raise NotImplementedError("Terminal option has to have argument.")
+            raise NotImplementedError(
+                "Terminal option is assumed to have argument."
+                " Non-`None` action={} is not supported".format())
 
         if nargs is not None and action is not None:
             raise TypeError("`nargs` and `action` are mutually exclusive")
@@ -194,7 +196,7 @@ class PyArgumentParser(object):
                 if dest in seen:
                     self._usage_and_error(
                         "{} provided more than twice"
-                        .format(" ".join(res.option.argdest.names)))
+                        .format(", ".join(res.option.argdest.names)))
                 seen.add(dest)
 
                 while len(res.values) < res.option.nargs:
@@ -216,6 +218,13 @@ class PyArgumentParser(object):
                     return
 
     def _find_matches(self, arg):
+        """
+        Return a list of `.Result`.
+
+        If value presents in `arg` (i.e., ``--long-option=value``), it
+        becomes the element of `.Result.values` (a list).  Otherwise,
+        this list has to be filled by the caller (`_parse_until_terminal`).
+        """
         for opt in self._options:
             if arg == opt.name:
                 return [Result(opt, [])]

--- a/julia/pseudo_python_cli.py
+++ b/julia/pseudo_python_cli.py
@@ -141,9 +141,7 @@ class PyArgumentParser(object):
             raise TypeError("`nargs` and `action` are mutually exclusive")
         if action == "store_true":
             nargs = 0
-        if nargs is None:
-            nargs = 1
-        assert isinstance(nargs, int)
+        assert nargs is None or isinstance(nargs, int)
         assert action in (None, "store_true")
 
         assert dest not in self._dests
@@ -199,7 +197,10 @@ class PyArgumentParser(object):
                         .format(", ".join(res.option.argdest.names)))
                 seen.add(dest)
 
-                while len(res.values) < res.option.nargs:
+                num_args = res.option.nargs
+                if num_args is None:
+                    num_args = 1
+                while len(res.values) < num_args:
                     try:
                         res.values.append(next(args_iter))
                     except StopIteration:
@@ -209,7 +210,7 @@ class PyArgumentParser(object):
                     setattr(ns, dest, True)
                 else:
                     value = res.values
-                    if res.option.nargs == 1:
+                    if res.option.nargs is None:
                         value, = value
                     setattr(ns, dest, value)
 
@@ -233,7 +234,7 @@ class PyArgumentParser(object):
                 if opt.is_long and arg[len(opt.name)] == "=":
                     return [Result(opt, [arg[len(opt.name) + 1:]])]
                 elif not opt.is_long:
-                    if opt.nargs > 0:
+                    if opt.nargs != 0:
                         return [Result(opt, [arg[len(opt.name):]])]
                     else:
                         results = [Result(opt, [])]

--- a/julia/pseudo_python_cli.py
+++ b/julia/pseudo_python_cli.py
@@ -121,8 +121,14 @@ def split_args(args):
             break
         elif a.startswith("-"):
             py_args.append(a)
-            if a[1] in ("c", "m"):
+            if a[1] in ("c", "m"):  # -mjson.tool
                 break
+            if "=" not in a:  # --option value
+                try:
+                    a = next(it)
+                except StopIteration:
+                    break
+                py_args.append(a)
         else:  # script
             py_args.append(a)
             break

--- a/julia/python_jl.py
+++ b/julia/python_jl.py
@@ -14,7 +14,7 @@ crash the whole process.  Consider using IPython >= 7 which can be launched by:
 import os
 import sys
 
-from .pseudo_python_cli import make_parser, split_args
+from .pseudo_python_cli import make_parser
 
 script_jl = """
 import PyCall
@@ -92,11 +92,8 @@ def parse_pyjl_args(args):
         Julia interpreter to be used.
         """)
 
-    py_args, script_args = split_args(args)
-    ns = parser.parse_args(py_args)
-
-    unused_args = list(remove_julia_options(py_args))
-    unused_args.extend(script_args)
+    ns = parser.parse_args(args)
+    unused_args = list(remove_julia_options(args))
     return ns, unused_args
 
 

--- a/julia/python_jl.py
+++ b/julia/python_jl.py
@@ -28,7 +28,7 @@ from __future__ import print_function, absolute_import
 import os
 import sys
 
-from .pseudo_python_cli import make_parser
+from .pseudo_python_cli import make_parser, parse_args_with
 
 script_jl = """
 import PyCall
@@ -106,7 +106,7 @@ def parse_pyjl_args(args):
         Julia interpreter to be used.
         """)
 
-    ns = parser.parse_args(args)
+    ns = parse_args_with(parser, args)
     unused_args = list(remove_julia_options(args))
     return ns, unused_args
 

--- a/julia/python_jl.py
+++ b/julia/python_jl.py
@@ -19,6 +19,8 @@ by::
    configured has to have PyJulia installed.
 """
 
+from __future__ import print_function, absolute_import
+
 import os
 import sys
 

--- a/julia/python_jl.py
+++ b/julia/python_jl.py
@@ -7,6 +7,10 @@ process.  This avoids the known problem with pre-compilation cache in
 Deiban-based distribution such as Ubuntu and Python executable installed by
 Conda in Linux.
 
+In Windows and macOS, this CLI is not necessary because those platforms do
+not have the pre-compilation issue mentioned above.  In fact, this CLI is
+known to not work on Windows at the moment.
+
 Although this script has -i option and it can do a basic REPL, contrl-c may
 crash the whole process.  Consider using IPython >= 7 which can be launched
 by::

--- a/julia/python_jl.py
+++ b/julia/python_jl.py
@@ -1,0 +1,112 @@
+"""
+Python interpreter inside a Julia process.
+
+This command line interface mimics a basic subset of Python program so that
+Python program involving calls to Julia functions can be run without setting
+up PyJulia (which is currently hard for some platforms).
+
+Although this script has -i option and it can do a basic REPL, contrl-c may
+crash the whole process.  Consider using IPython >= 7 which can be launched by:
+
+    python -m IPython
+"""
+
+import os
+import sys
+
+from .pseudo_python_cli import make_parser, split_args
+
+script_jl = """
+import PyCall
+
+# Initialize julia.Julia once so that subsequent calls of julia.Julia()
+# uses pre-configured DLL.
+PyCall.pyimport("julia")[:Julia](init_julia=false)
+
+let code = PyCall.pyimport("julia.pseudo_python_cli")[:main](ARGS)
+    if code isa Integer
+        exit(code)
+    end
+end
+"""
+
+
+def remove_julia_options(args):
+    """
+    Remove options used in this Python process.
+
+    >>> list(remove_julia_options(["a", "b", "c"]))
+    ['a', 'b', 'c']
+    >>> list(remove_julia_options(["a", "--julia", "julia", "b", "c"]))
+    ['a', 'b', 'c']
+    >>> list(remove_julia_options(["a", "b", "c", "--julia=julia"]))
+    ['a', 'b', 'c']
+    """
+    it = iter(args)
+    for a in it:
+        if a == "--julia":
+            try:
+                next(it)
+            except StopIteration:
+                return
+            continue
+        elif a.startswith("--julia="):
+            continue
+        yield a
+
+
+def parse_pyjl_args(args):
+    """
+    Return a pair of parsed result and "unused" arguments.
+
+    Returns
+    -------
+    ns : argparse.Namespace
+        Parsed result.  Only `ns.julia` is relevant here.
+    unused_args : list
+        Arguments to be parsed (again) by `.pseudo_python_cli.main`.
+
+    Examples
+    --------
+    >>> ns, unused_args = parse_pyjl_args([])
+    >>> ns.julia
+    'julia'
+    >>> unused_args
+    []
+    >>> ns, unused_args = parse_pyjl_args(
+    ...     ["--julia", "julia-dev", "-i", "-c", "import julia"])
+    >>> ns.julia
+    'julia-dev'
+    >>> unused_args
+    ['-i', '-c', 'import julia']
+    """
+    # Mix the options we need in this Python process with the Python
+    # arguments to be parsed in the "subprocess".  This way, we get a
+    # parse error right now without initiating Julia interpreter and
+    # importing PyCall.jl etc. to get an extra speedup for the
+    # abnormal case (including -h/--help and -V/--version).
+    parser = make_parser(description=__doc__)
+    parser.add_argument(
+        "--julia", default="julia",
+        help="""
+        Julia interpreter to be used.
+        """)
+
+    py_args, script_args = split_args(args)
+    ns = parser.parse_args(py_args)
+
+    unused_args = list(remove_julia_options(py_args))
+    unused_args.extend(script_args)
+    return ns, unused_args
+
+
+def main(args=None):
+    if args is None:
+        args = sys.argv[1:]
+    ns, unused_args = parse_pyjl_args(args)
+    julia = ns.julia
+    os.execvp(julia, [julia, "-e", script_jl, "--"] + unused_args)
+
+
+if __name__ == "__main__":
+    main()

--- a/julia/python_jl.py
+++ b/julia/python_jl.py
@@ -28,7 +28,11 @@ from __future__ import print_function, absolute_import
 import os
 import sys
 
-from .pseudo_python_cli import make_parser, parse_args_with
+from .pseudo_python_cli import make_parser, parse_args_with, ARGUMENT_HELP
+
+PYJL_ARGUMENT_HELP = ARGUMENT_HELP + """
+  --julia JULIA  Julia interpreter to be used. (default: julia)
+"""
 
 script_jl = """
 import PyCall
@@ -99,12 +103,8 @@ def parse_pyjl_args(args):
     # parse error right now without initiating Julia interpreter and
     # importing PyCall.jl etc. to get an extra speedup for the
     # abnormal case (including -h/--help and -V/--version).
-    parser = make_parser(description=__doc__)
-    parser.add_argument(
-        "--julia", default="julia",
-        help="""
-        Julia interpreter to be used.
-        """)
+    parser = make_parser(description=__doc__ + PYJL_ARGUMENT_HELP)
+    parser.add_argument("--julia", default="julia")
 
     ns = parse_args_with(parser, args)
     unused_args = list(remove_julia_options(args))

--- a/julia/python_jl.py
+++ b/julia/python_jl.py
@@ -2,13 +2,21 @@
 Python interpreter inside a Julia process.
 
 This command line interface mimics a basic subset of Python program so that
-Python program involving calls to Julia functions can be run without setting
-up PyJulia (which is currently hard for some platforms).
+Python program involving calls to Julia functions can be run in a *Julia*
+process.  This avoids the known problem with pre-compilation cache in
+Deiban-based distribution such as Ubuntu and Python executable installed by
+Conda in Linux.
 
 Although this script has -i option and it can do a basic REPL, contrl-c may
-crash the whole process.  Consider using IPython >= 7 which can be launched by:
+crash the whole process.  Consider using IPython >= 7 which can be launched
+by::
 
-    python -m IPython
+    python-jl -m IPython
+
+.. NOTE::
+
+   For this command to work, Python environment with which PyCall.jl is
+   configured has to have PyJulia installed.
 """
 
 import os

--- a/setup.py
+++ b/setup.py
@@ -45,5 +45,10 @@ setup(name='julia',
       ],
       url='http://julialang.org',
       packages=['julia'],
-      package_data={'julia': ['fake-julia/*']}
-     )
+      package_data={'julia': ['fake-julia/*']},
+      entry_points={
+          "console_scripts": [
+              "python-jl = julia.python_jl:main",
+          ],
+      },
+      )

--- a/test/test_pseudo_python_cli.py
+++ b/test/test_pseudo_python_cli.py
@@ -20,11 +20,33 @@ def make_dict(**kwargs):
     ("-m ipykernel_launcher -f FILE",
      make_dict(module="ipykernel_launcher",
                args=shlex.split("-f FILE"))),
+    ("-", make_dict(script="-")),
+    ("- a", make_dict(script="-", args=["a"])),
+    ("script", make_dict(script="script")),
+    ("script a", make_dict(script="script", args=["a"])),
 ])
-def test_parse_args(args, desired):
+def test_valid_args(args, desired):
     ns = parse_args(shlex.split(args))
     actual = vars(ns)
     assert actual == desired
+
+
+@pytest.mark.parametrize("args", [
+    "-m",
+    "-c",
+    "-i -m",
+    # They are invalid in python CLI but works in argparse (which is
+    # probably OK):
+    pytest.mark.xfail("-V -m"),
+    pytest.mark.xfail("-h -m"),
+])
+def test_invalid_args(args, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(shlex.split(args))
+    assert exc_info.value.code != 0
+
+    captured = capsys.readouterr()
+    assert "usage:" in captured.err
 
 
 @pytest.mark.parametrize("cli_args", [

--- a/test/test_pseudo_python_cli.py
+++ b/test/test_pseudo_python_cli.py
@@ -1,0 +1,45 @@
+import shlex
+
+import pytest
+
+from julia.pseudo_python_cli import parse_args
+
+
+def make_dict(**kwargs):
+    ns = parse_args([])
+    return dict(vars(ns), **kwargs)
+
+
+@pytest.mark.parametrize("args, desired", [
+    ("-m json.tool -h", make_dict(module="json.tool", args=["-h"])),
+    ("-mjson.tool -h", make_dict(module="json.tool", args=["-h"])),
+    ("-m ipykernel install --user --name NAME --display-name DISPLAY_NAME",
+     make_dict(module="ipykernel",
+               args=shlex.split("install --user --name NAME"
+                                " --display-name DISPLAY_NAME"))),
+    ("-m ipykernel_launcher -f FILE",
+     make_dict(module="ipykernel_launcher",
+               args=shlex.split("-f FILE"))),
+])
+def test_parse_args(args, desired):
+    ns = parse_args(shlex.split(args))
+    actual = vars(ns)
+    assert actual == desired
+
+
+@pytest.mark.parametrize("cli_args", [
+    ["-h"],
+    ["-i", "--help"],
+    ["-h", "-i"],
+    ["-hi"],
+    ["-ih"],
+    ["-h", "-m", "json.tool"],
+    ["-h", "-mjson.tool"],
+])
+def test_help_option(cli_args, capsys):
+    with pytest.raises(SystemExit) as exc_info:
+        parse_args(cli_args)
+    assert exc_info.value.code == 0
+
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out

--- a/test/test_python_jl.py
+++ b/test/test_python_jl.py
@@ -1,3 +1,4 @@
+from textwrap import dedent
 import os
 import subprocess
 
@@ -59,10 +60,22 @@ def test_cli_quick_pass_no_julia(cli_args):
     not PYJULIA_TEST_REBUILD,
     reason="PYJULIA_TEST_REBUILD=yes is not set")
 def test_cli_import():
-    cli_args = ["-c", "from julia import Base; Base.banner()"]
+    cli_args = ["-c", dedent("""
+    from julia import Base
+    Base.banner()
+    from julia import Main
+    Main.x = 1
+    assert Main.x == 1
+    """)]
     if JULIA:
         cli_args = ["--julia", JULIA] + cli_args
     output = subprocess.check_output(
         ["python-jl"] + cli_args,
         universal_newlines=True)
     assert "julialang.org" in output
+
+# Embedded julia does not have usual the Main.eval and Main.include.
+# Main.eval is Core.eval.  Let's test that we are not relying on this
+# special behavior.
+#
+# See also: https://github.com/JuliaLang/julia/issues/28825

--- a/test/test_python_jl.py
+++ b/test/test_python_jl.py
@@ -1,5 +1,6 @@
 from textwrap import dedent
 import os
+import shlex
 import subprocess
 
 import pytest
@@ -13,15 +14,15 @@ PYJULIA_TEST_REBUILD = os.environ.get("PYJULIA_TEST_REBUILD", "no") == "yes"
 JULIA = os.environ.get("JULIA_EXE")
 
 
-@pytest.mark.parametrize("cli_args", [
-    ["-h"],
-    ["-i", "--help"],
-    ["--julia", "false", "-h"],
-    ["--julia", "false", "-i", "--help"],
+@pytest.mark.parametrize("args", [
+    "-h",
+    "-i --help",
+    "--julia false -h",
+    "--julia false -i --help",
 ])
-def test_help_option(cli_args, capsys):
+def test_help_option(args, capsys):
     with pytest.raises(SystemExit) as exc_info:
-        parse_pyjl_args(cli_args)
+        parse_pyjl_args(shlex.split(args))
     assert exc_info.value.code == 0
 
     captured = capsys.readouterr()
@@ -29,27 +30,27 @@ def test_help_option(cli_args, capsys):
 
 
 quick_pass_cli_args = [
-    ["-h"],
-    ["-i", "--help"],
-    ["-V"],
-    ["--version", "-c", "1/0"],
+    "-h",
+    "-i --help",
+    "-V",
+    "--version -c 1/0",
 ]
 
 
-@pytest.mark.parametrize("cli_args", quick_pass_cli_args)
-def test_cli_quick_pass(cli_args):
+@pytest.mark.parametrize("args", quick_pass_cli_args)
+def test_cli_quick_pass(args):
     subprocess.check_output(
-        ["python-jl"] + cli_args,
+        ["python-jl"] + shlex.split(args),
     )
 
 
 @pytest.mark.skipif(
     not which("false"),
     reason="false command not found")
-@pytest.mark.parametrize("cli_args", quick_pass_cli_args)
-def test_cli_quick_pass_no_julia(cli_args):
+@pytest.mark.parametrize("args", quick_pass_cli_args)
+def test_cli_quick_pass_no_julia(args):
     subprocess.check_output(
-        ["python-jl", "--julia", "false"] + cli_args,
+        ["python-jl", "--julia", "false"] + shlex.split(args),
     )
 
 
@@ -60,7 +61,7 @@ def test_cli_quick_pass_no_julia(cli_args):
     not PYJULIA_TEST_REBUILD,
     reason="PYJULIA_TEST_REBUILD=yes is not set")
 def test_cli_import():
-    cli_args = ["-c", dedent("""
+    args = ["-c", dedent("""
     from julia import Base
     Base.banner()
     from julia import Main
@@ -68,9 +69,9 @@ def test_cli_import():
     assert Main.x == 1
     """)]
     if JULIA:
-        cli_args = ["--julia", JULIA] + cli_args
+        args = ["--julia", JULIA] + args
     output = subprocess.check_output(
-        ["python-jl"] + cli_args,
+        ["python-jl"] + args,
         universal_newlines=True)
     assert "julialang.org" in output
 

--- a/test/test_python_jl.py
+++ b/test/test_python_jl.py
@@ -32,7 +32,7 @@ quick_pass_cli_args = [
 
 @pytest.mark.parametrize("cli_args", quick_pass_cli_args)
 def test_cli_quick_pass(cli_args):
-    subprocess.check_call(
+    subprocess.check_output(
         ["python-jl"] + cli_args,
     )
 
@@ -42,7 +42,7 @@ def test_cli_quick_pass(cli_args):
     reason="false command not found")
 @pytest.mark.parametrize("cli_args", quick_pass_cli_args)
 def test_cli_quick_pass_no_julia(cli_args):
-    subprocess.check_call(
+    subprocess.check_output(
         ["python-jl", "--julia", "false"] + cli_args,
     )
 

--- a/test/test_python_jl.py
+++ b/test/test_python_jl.py
@@ -6,6 +6,8 @@ import pytest
 from julia.core import which
 from julia.python_jl import parse_pyjl_args
 
+is_windows = os.name == "nt"
+
 PYJULIA_TEST_REBUILD = os.environ.get("PYJULIA_TEST_REBUILD", "no") == "yes"
 JULIA = os.environ.get("JULIA_EXE")
 
@@ -50,6 +52,9 @@ def test_cli_quick_pass_no_julia(cli_args):
     )
 
 
+@pytest.mark.skipif(
+    is_windows,
+    reason="python-jl is not supported in Windows")
 @pytest.mark.skipif(
     not PYJULIA_TEST_REBUILD,
     reason="PYJULIA_TEST_REBUILD=yes is not set")

--- a/test/test_python_jl.py
+++ b/test/test_python_jl.py
@@ -1,0 +1,60 @@
+import os
+import subprocess
+
+import pytest
+
+from julia.core import which
+from julia.python_jl import parse_pyjl_args
+
+PYJULIA_TEST_REBUILD = os.environ.get("PYJULIA_TEST_REBUILD", "no") == "yes"
+JULIA = os.environ.get("JULIA_EXE")
+
+
+@pytest.mark.parametrize("cli_args", [
+    ["-h"],
+    ["-i", "--help"],
+    ["--julia", "false", "-h"],
+    ["--julia", "false", "-i", "--help"],
+])
+def test_help_option(cli_args):
+    with pytest.raises(SystemExit) as exc_info:
+        parse_pyjl_args(cli_args)
+    assert exc_info.value.code == 0
+
+
+quick_pass_cli_args = [
+    ["-h"],
+    ["-i", "--help"],
+    ["-V"],
+    ["--version", "-c", "1/0"],
+]
+
+
+@pytest.mark.parametrize("cli_args", quick_pass_cli_args)
+def test_cli_quick_pass(cli_args):
+    subprocess.check_call(
+        ["python-jl"] + cli_args,
+    )
+
+
+@pytest.mark.skipif(
+    not which("false"),
+    reason="false command not found")
+@pytest.mark.parametrize("cli_args", quick_pass_cli_args)
+def test_cli_quick_pass_no_julia(cli_args):
+    subprocess.check_call(
+        ["python-jl", "--julia", "false"] + cli_args,
+    )
+
+
+@pytest.mark.skipif(
+    not PYJULIA_TEST_REBUILD,
+    reason="PYJULIA_TEST_REBUILD=yes is not set")
+def test_cli_import():
+    cli_args = ["-c", "from julia import Base; Base.banner()"]
+    if JULIA:
+        cli_args = ["--julia", JULIA] + cli_args
+    output = subprocess.check_output(
+        ["python-jl"] + cli_args,
+        universal_newlines=True)
+    assert "julialang.org" in output

--- a/test/test_python_jl.py
+++ b/test/test_python_jl.py
@@ -16,10 +16,13 @@ JULIA = os.environ.get("JULIA_EXE")
     ["--julia", "false", "-h"],
     ["--julia", "false", "-i", "--help"],
 ])
-def test_help_option(cli_args):
+def test_help_option(cli_args, capsys):
     with pytest.raises(SystemExit) as exc_info:
         parse_pyjl_args(cli_args)
     assert exc_info.value.code == 0
+
+    captured = capsys.readouterr()
+    assert "usage:" in captured.out
 
 
 quick_pass_cli_args = [

--- a/tox.ini
+++ b/tox.ini
@@ -21,6 +21,9 @@ commands =
     # used to build PyCall.jl via julia/with_rebuilt.py (when
     # PYJULIA_TEST_REBUILD=yes).
 
+    python-jl --help
+    python-jl -c 'from julia import Base; Base.banner()'
+
 passenv =
     # Allow a workaround for "error initializing LibGit2 module":
     # https://github.com/JuliaLang/julia/issues/18693

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,6 @@ commands =
     # used to build PyCall.jl via julia/with_rebuilt.py (when
     # PYJULIA_TEST_REBUILD=yes).
 
-    python-jl --help
-    python-jl -c 'from julia import Base; Base.banner()'
-
 passenv =
     # Allow a workaround for "error initializing LibGit2 module":
     # https://github.com/JuliaLang/julia/issues/18693


### PR DESCRIPTION
This PR adds a CLI `python-jl` which acts like `python` CLI but executed as a `julia` process. This way, PyCall can use normal precompilation cache so that PyJulia can be used with Python installed in Debian/Ubuntu and conda #185.

The users just have to use `python-jl script.py` instead of `python script.py`.

(previously: https://github.com/JuliaPy/PyCall.jl/pull/562)
