### PR TITLE
Re-import PyCall in case init_julia=False is passed

### DIFF
--- a/julia/core.py
+++ b/julia/core.py
@@ -645,6 +645,7 @@ class Julia(object):
                 end
                 """)
 
+            # This is mainly for initiating the precompilation:
             self._call(u"using PyCall")
 
             if use_separate_cache:
@@ -658,6 +659,10 @@ class Julia(object):
                     rm(backup; force=true)
                 end
                 """)
+
+        # Currently, PyJulia assumes that `Main.PyCall` exsits.  Thus, we need
+        # to import `PyCall` again here in case `init_julia=False` is passed:
+        self._call(u"using PyCall")
 
         # Whether we initialized Julia or not, we MUST create at least one
         # instance of PyObject and the convert function. Since these will be


### PR DESCRIPTION
It fixes the following scenario:

```julia
julia> m = Module();

julia> Base.eval(m, quote
       using PyCall
       end)

julia> Base.eval(m, quote
       py"""
       from julia import Julia
       Julia(init_julia=False)
       """
       end)
```