### PR TITLE
Change default tox envlist to py3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py36
+envlist = py3
 
 [testenv]
 deps =


### PR DESCRIPTION
As switching Python executables is not supported with Julia >= 0.7 at the moment, running tox with different environments requires passing PYJULIA_TEST_REBUILD=yes which is cumbersome.  So let's default to single environment for now.