### PR TITLE
Copy LICENSE into install-julia.sh

### DIFF
--- a/ci/install-julia.sh
+++ b/ci/install-julia.sh
@@ -2,6 +2,31 @@
 # install julia vX.Y.Z:  ./install-julia.sh X.Y.Z
 # install julia nightly: ./install-julia.sh nightly
 
+# LICENSE
+#
+# Copyright &copy; 2013 by Steven G. Johnson, Fernando Perez, Jeff
+# Bezanson, Stefan Karpinski, Keno Fischer, Jake Bolewski, Takafumi
+# Arakaki, and other contributors.
+#
+# Permission is hereby granted, free of charge, to any person obtaining
+# a copy of this software and associated documentation files (the
+# "Software"), to deal in the Software without restriction, including
+# without limitation the rights to use, copy, modify, merge, publish,
+# distribute, sublicense, and/or sell copies of the Software, and to
+# permit persons to whom the Software is furnished to do so, subject to
+# the following conditions:
+#
+# The above copyright notice and this permission notice shall be
+# included in all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+# EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+# MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+# NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+# LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+# OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+# WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
 # stop on error
 set -e
 VERSION="$1"


### PR DESCRIPTION
This patch adds LICENSE in install-julia.sh as a comment.  This is for making it easy for people to "vendor" this script into their project for CI.

see: https://discourse.julialang.org/t/install-script-for-linux-for-use-in-container/19301
