### PR TITLE
Revert "Ignore failure of test_compiled_modules_no in Windows"

### DIFF
--- a/test/test_libjulia.py
+++ b/test/test_libjulia.py
@@ -5,13 +5,10 @@ import pytest
 from .test_compatible_exe import runcode
 from julia.core import JuliaInfo
 
-xfail_if_windows = pytest.mark.xfail if sys.platform == "win32" else lambda x: x
-
 juliainfo = JuliaInfo.load()
 
 
 @pytest.mark.skipif("juliainfo.version_info < (0, 7)")
-@xfail_if_windows  # https://github.com/JuliaPy/PyCall.jl/pull/661
 def test_compiled_modules_no():
     runcode(
         sys.executable,


### PR DESCRIPTION
This reverts commit a6d304a005e39442e183af3e0fcb8c3f8f5ad612.

This test passes now as https://github.com/JuliaPy/PyCall.jl/pull/661
is merged and released in PyCall v1.91.0.