### PR TITLE
Load modules with correct name based on `fullname`

### DIFF
--- a/julia/pyjulia_helper.jl
+++ b/julia/pyjulia_helper.jl
@@ -1,5 +1,36 @@
 module _PyJuliaHelper
 
+if VERSION < v"0.7-"
+nameof(m::Module) = ccall(:jl_module_name, Ref{Symbol}, (Any,), m)
+
+parentmodule(m::Module) = ccall(:jl_module_parent, Ref{Module}, (Any,), m)
+
+function fullname(m::Module)
+    mn = nameof(m)
+    if m === Main || m === Base || m === Core
+        return (mn,)
+    end
+    mp = parentmodule(m)
+    if mp === m
+        return (mn,)
+    end
+    return (fullname(mp)..., mn)
+end
+end  # if
+
+"""
+    fullnamestr(m)
+
+# Examples
+```jldoctest
+julia> fullnamestr(Base.Enums)
+"Base.Enums"
+```
+"""
+fullnamestr(m) = join(fullname(m), ".")
+
+isdefinedstr(parent, member) = isdefined(parent, Symbol(member))
+
 if VERSION >= v"0.7-"
     import REPL
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -116,6 +116,12 @@ def test_import_julia_submodule(julia):
     from julia.Base import Enums
 
     assert isinstance(Enums, ModuleType)
+    assert Enums.__name__ == "julia.Base.Enums"
+    assert julia.fullname(Enums) == "Base.Enums"
+
+
+def test_getattr_submodule(Main):
+    assert Main._PyJuliaHelper.IOPiper.__name__ == "julia.Main._PyJuliaHelper.IOPiper"
 
 
 def test_star_import_julia_module(julia):


### PR DESCRIPTION
Before this patch:

    In [1]: from julia import Main
       ...: Main.eval("import Base.Enums")
       ...: from julia.Base import Enums
       ...: Enums
    Out[1]: <PyCall.jlwrap Base.Enums>

After this patch, `Out[1]` is `<module 'julia.Base.Enums' ...>` as expected.