### PR TITLE
Intuitive handling of sysimage relative path

### DIFF
--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -614,12 +614,9 @@ class LibJulia(BaseLibJulia):
         Path to system image.  This is passed to `jl_init_with_image`
         unless overridden by argument ``option`` to `init_julia`.
 
-        .. warning::
-
-            Unlike `jl_init_with_image` C API, relative path is not
-            interpreted as relative to `bindir`.  Instead, relative
-            path is resolved using `os.path.realpath` before passed to
-            Julia.
+        If `sysimage` is a relative path, it is interpreted relative
+        to the current directory (rather than relative to the Julia
+        `bindir` as in the `jl_init_with_image` C API).
     """
 
     @classmethod

--- a/test/test_compatible_exe.py
+++ b/test/test_compatible_exe.py
@@ -45,7 +45,7 @@ except ImportError:
     run = _run_fallback
 
 
-def runcode(python, code, check=False):
+def runcode(python, code, check=False, **kwargs):
     """Run `code` in `python`."""
     proc = run(
         [python],
@@ -60,6 +60,7 @@ def runcode(python, code, check=False):
                 os.path.dirname(os.path.dirname(os.path.realpath(__file__))), "src"
             ),
         ),
+        **kwargs
     )
     print_completed_proc(proc)
     if check:

--- a/test/test_libjulia.py
+++ b/test/test_libjulia.py
@@ -23,7 +23,8 @@ def test_compiled_modules_no():
         print("use_compiled_modules =", use_compiled_modules)
         assert use_compiled_modules == 0
         """,
-        check=True)
+        check=True,
+    )
 
 
 @pytest.mark.skipif("not juliainfo.is_compatible_python()")
@@ -50,5 +51,31 @@ def test_custom_sysimage(tmpdir):
         print("actual =", actual)
         print("sysimage =", sysimage)
         assert actual == sysimage
-        """.format(sysimage),
-        check=True)
+        """.format(
+            sysimage
+        ),
+        check=True,
+    )
+
+
+def test_non_existing_sysimage(tmpdir):
+    proc = runcode(
+        sys.executable,
+        """
+        import sys
+        from julia.core import enable_debug, LibJulia
+
+        enable_debug()
+
+        api = LibJulia.load()
+        try:
+            api.init_julia(["--sysimage", "sys.so"])
+        except RuntimeError as err:
+            print(err)
+            assert "System image" in str(err)
+            assert "does not exist" in str(err)
+            sys.exit(55)
+        """,
+        cwd=str(tmpdir),
+    )
+    assert proc.returncode == 55


### PR DESCRIPTION
Julia tries to interpret `sysimage` as a path relative to `bindir` and aborts if not found.  With this PR, it is turned to absolute path before passed to Julia.

See also: https://github.com/JuliaLang/julia/pull/31492