### PR TITLE
Rename pytest plugin to "julia"

### DIFF
--- a/docs/source/pytest.rst
+++ b/docs/source/pytest.rst
@@ -17,10 +17,10 @@ tricky aspects of PyJulia initialization:
 
 * The tests requiring Julia can be skipped with :option:`--no-julia`.
 
-Use |pytest -p no:pyjulia|_ to disable PyJulia plugin.
+Use |pytest -p no:julia|_ to disable PyJulia plugin.
 
-.. |pytest -p no:pyjulia| replace:: ``pytest -p no:pyjulia``
-.. _pytest -p no:pyjulia:
+.. |pytest -p no:julia| replace:: ``pytest -p no:julia``
+.. _pytest -p no:julia:
    https://docs.pytest.org/en/latest/plugins.html#deactivating-unregistering-a-plugin-by-name
 
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,7 @@ setup(name='julia',
               "python-jl = julia.python_jl:main",
           ],
           "pytest11": [
-              "pyjulia = julia.pytestplugin",
+              "julia = julia.pytestplugin",
           ],
       },
       # We bundle Julia scripts etc. inside `julia` directory.  Thus,


### PR DESCRIPTION
In Python namespaces we haven't been using `pyjulia`.  It is a bit odd to use `pyjulia` only for pytest plugin.
