### PR TITLE
add variable interpolation

### DIFF
--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -70,7 +70,7 @@ You can then use, e.g.,
 In IPython (and therefore in Jupyter), you can directly execute Julia
 code using `%%julia` magic:
 
-```
+```none
 In [1]: %load_ext julia.magic
 Initializing Julia interpreter. This may take some time...
 
@@ -84,6 +84,35 @@ In [2]: %%julia
   | | |_| | | | (_| |  |  Version 1.0.1 (2018-09-29)
  _/ |\__'_|_|_|\__'_|  |  Official https://julialang.org/ release
 |__/                   |
+```
+
+Any `$var` or `$(var)` expressions that appear in the Julia code (except in
+comments or string literals) are evaluated in Python and passed to Julia. Use
+`$$var` to insert a literal `$var` in Julia code.
+
+```none
+In [3]: foo = [[1,2],[3,4]]
+
+In [4]: %julia $foo .+ 1
+
+Out[4]: 
+array([[2, 3],
+       [4, 5]], dtype=int64)
+       
+In [22]: %%julia
+   ...: bar=3
+   ...: :($$bar)
+   
+Out[22]: 3
+
+```
+
+Variables are automatically converted between equivalent Python/Julia types (should they exist) using PyCall. Note below that `1`, `x`, and the tuple itself are converted to Julia `Int64`, `String`, and `Tuple`, respectively, although the function `abs` and the result of `typeof` are not.
+
+```none
+In [6]: %julia typeof($(1,"x",abs))
+
+Out[6]: <PyCall.jlwrap Tuple{Int64,String,PyObject}>
 ```
 
 #### IPython configuration

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -91,15 +91,22 @@ In [5]: %julia sum(py"[x**2 for x in arr]")
 Out[5]: 14
 ```
 
-Python interpolation is not performed inside of strings (instead this is treated as regular Julia string interpolation), and can also be overridden elsewhere by using `$$...` to insert a literal `$...`:
+Interpolation from Python is only done outside of strings and quote blocks; to interpolate into these, you'll need to "escape" them one extra time:
 
 ```julia
-In [6]: %julia foo=3; "$foo"
-Out[6]: '3'
-
-In [7]: %julia bar=3; :($$bar)
-Out[7]: 3
+In [6]: foo="Python"
+        %julia foo="Julia"
+        %julia "this is $foo", "this is $($foo)"
+Out[6]: ('this is Julia', 'this is Python')
 ```
+
+Expressions inside of macros are never interpolated from Python:
+
+```julia
+In [7]: %julia @eval $foo
+Out[7]: 'Julia'
+```
+
 
 Variables are automatically converted between equivalent Python/Julia types (should they exist). You can turn this off by appending `o` to the Python string:
 

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -79,9 +79,10 @@ array([[2, 3],
        [4, 5]], dtype=int64)
 ```
 
-You can "interpolate" Python objects into Julia code via `$var` for the value of single variables or `py"expression"` for the result of any arbitrary Python code:
+You can call Python code from inside of `%julia` blocks via `$var` for accessing single variables or `py"..."` for more complex expressions:
+
 ```julia
-In [3]: arr = [1,2,3]
+In [3]: arr = [1, 2, 3]
 
 In [4]: %julia $arr .+ 1
 Out[4]: 
@@ -91,31 +92,30 @@ In [5]: %julia sum(py"[x**2 for x in arr]")
 Out[5]: 14
 ```
 
-Interpolation from Python is only done outside of strings and quote blocks; to interpolate into these, you'll need to "escape" them one extra time:
+Inside of strings and quote blocks, `$var` and `py"..."` don't call Python and instead retain their usual Julia behavior. To call Python code in these cases, you can "escape" one extra time:
 
 ```julia
-In [6]: foo="Python"
-        %julia foo="Julia"
-        %julia "this is $foo", "this is $($foo)"
+In [6]: foo = "Python"
+        %julia foo = "Julia"
+        %julia ("this is $foo", "this is $($foo)")
 Out[6]: ('this is Julia', 'this is Python')
 ```
 
-Expressions inside of macros are never interpolated from Python:
+Expressions in macro arguments also always retain the Julia behavior:
 
 ```julia
 In [7]: %julia @eval $foo
 Out[7]: 'Julia'
 ```
 
-
-Variables are automatically converted between equivalent Python/Julia types (should they exist). You can turn this off by appending `o` to the Python string:
+Results are automatically converted between equivalent Python/Julia types (should they exist). You can turn this off by appending `o` to the Python string:
 
 ```python
 In [8]: %julia typeof(py"1"), typeof(py"1"o)
 Out[8]: (<PyCall.jlwrap Int64>, <PyCall.jlwrap PyObject>)
 ```
 
-Interpolated variables obey Python scope, as expected:
+Code inside `%julia` blocks obeys the Python scope:
 
 ```python
 In [9]: x = "global"

--- a/docs/source/usage.md
+++ b/docs/source/usage.md
@@ -67,7 +67,7 @@ You can then use, e.g.,
 
 ### IPython magic
 
-In IPython (and therefore in Jupyter), you can directly execute Julia code using `%%julia` magic:
+In IPython (and therefore in Jupyter), you can directly execute Julia code using `%julia` magic:
 
 ```python
 In [1]: %load_ext julia.magic
@@ -79,8 +79,7 @@ array([[2, 3],
        [4, 5]], dtype=int64)
 ```
 
-You can "interpolate" Python results into Julia code via `$var` for single variable names, `$(expression)` for *most* Python code (although notably excluding comprehensions and any Python syntax which is not also valid Julia syntax), or `py"expression"` for *any* arbitrary Python code:
-
+You can "interpolate" Python objects into Julia code via `$var` for the value of single variables or `py"expression"` for the result of any arbitrary Python code:
 ```julia
 In [3]: arr = [1,2,3]
 
@@ -88,40 +87,37 @@ In [4]: %julia $arr .+ 1
 Out[4]: 
 array([2, 3, 4], dtype=int64)
 
-In [5]: %julia $(len(arr))
-Out[5]: 3
-
-In [6]: %julia py"[x**2 for x in arr]"
-Out[6]: array([1, 4, 9], dtype=int64)
+In [5]: %julia sum(py"[x**2 for x in arr]")
+Out[5]: 14
 ```
 
-Interpolation is never performed inside of strings. If you wish to override interpolation elsewhere, use `$$...` to insert a literal `$...`:
+Python interpolation is not performed inside of strings (instead this is treated as regular Julia string interpolation), and can also be overridden elsewhere by using `$$...` to insert a literal `$...`:
 
 ```julia
-In [7]: %julia foo=3; "$foo"
-Out[7]: '3'
+In [6]: %julia foo=3; "$foo"
+Out[6]: '3'
 
-In [8]: %julia bar=3; :($$bar)
-Out[8]: 3
+In [7]: %julia bar=3; :($$bar)
+Out[7]: 3
 ```
 
 Variables are automatically converted between equivalent Python/Julia types (should they exist). You can turn this off by appending `o` to the Python string:
 
 ```python
-In [9]: %julia typeof(py"1"), typeof(py"1"o)
-Out[9]: (<PyCall.jlwrap Int64>, <PyCall.jlwrap PyObject>)
+In [8]: %julia typeof(py"1"), typeof(py"1"o)
+Out[8]: (<PyCall.jlwrap Int64>, <PyCall.jlwrap PyObject>)
 ```
 
-Note that interpolated variables always refer to the global Python scope:
+Interpolated variables obey Python scope, as expected:
 
 ```python
-In [10]: x = "global"
-    ...: def f():
-    ...:     x = "local"
-    ...:     ret = %julia py"x"
-    ...:     return ret
-    ...: f()
-Out[10]: 'global'
+In [9]: x = "global"
+   ...: def f():
+   ...:     x = "local"
+   ...:     ret = %julia py"x"
+   ...:     return ret
+   ...: f()
+Out[9]: 'local'
 ```
 
 #### IPython configuration

--- a/src/julia/magic.py
+++ b/src/julia/magic.py
@@ -104,9 +104,17 @@ class JuliaMagics(Magics):
         """
         src = compat.unicode_type(line if cell is None else cell)
 
+        # We assume the caller's frame is the first parent frame not in the
+        # IPython module. This seems to work with IPython back to ~v5, and
+        # is at least somewhat immune to future IPython internals changes,
+        # although by no means guaranteed to be perfect.
+        caller_frame = sys._getframe(3)
+        while caller_frame.f_globals.get('__name__').startswith("IPython"):
+            caller_frame = caller_frame.f_back
+        
         return self._julia.eval("""
         _PyJuliaHelper.@prepare_for_pyjulia_call begin %s end
-        """%src)(self.shell.user_ns, sys._getframe(4).f_locals)
+        """%src)(self.shell.user_ns, caller_frame.f_locals)
 
 # Add to the global docstring the class information.
 __doc__ = __doc__.format(

--- a/src/julia/magic.py
+++ b/src/julia/magic.py
@@ -22,12 +22,18 @@ from __future__ import print_function, absolute_import
 import sys
 import warnings
 
-from IPython.core.magic import Magics, magics_class, line_cell_magic, no_var_expand
+from IPython.core.magic import Magics, magics_class, line_cell_magic
 from IPython.utils import py3compat as compat
 from traitlets import Bool, Enum
 
 from .core import Julia, JuliaError
 from .tools import redirect_output_streams
+
+try:
+    from IPython.core.magic import no_var_expand
+except ImportError:
+    def no_var_expand(f):
+        return f
 
 #-----------------------------------------------------------------------------
 # Main classes

--- a/src/julia/magic.py
+++ b/src/julia/magic.py
@@ -100,7 +100,7 @@ class JuliaMagics(Magics):
 
         return self._julia.eval("""
         _PyJuliaHelper.@prepare_for_pyjulia_call begin %s end
-        """%src)(self.shell.user_ns, self.shell.user_ns)
+        """%src)(self.shell.user_ns, sys._getframe(4).f_locals)
 
 # Add to the global docstring the class information.
 __doc__ = __doc__.format(

--- a/src/julia/pyjulia_helper.jl
+++ b/src/julia/pyjulia_helper.jl
@@ -51,7 +51,7 @@ end
 
 # takes an expression like `$foo + 1` and turns it into a pyfunction
 # `(globals,locals) -> convert(PyAny, pyeval_("foo",globals,locals,PyAny)) + 1`
-# so that Python code can all it and just pass the appropriate globals/locals
+# so that Python code can call it and just pass the appropriate globals/locals
 # dicts to perform the interpolation. 
 macro prepare_for_pyjulia_call(ex)
     

--- a/src/julia/pyjulia_helper.jl
+++ b/src/julia/pyjulia_helper.jl
@@ -73,8 +73,13 @@ macro prepare_for_pyjulia_call(ex)
         if isexpr(x, :$)
             if isexpr(x.args[1], :$)
                 x.args[1], false
-            else
+            elseif x.args[1] isa Symbol
                 make_pyeval(x.args[1]), false
+            else
+                error("""syntax error in: \$($(string(x.args[1])))
+                Use py"..." instead of \$(...) for interpolating Python expressions, 
+                or \$\$(...) for a literal Julia \$(...).
+                """)
             end
         elseif isexpr(x, :macrocall) && x.args[1]==Symbol("@py_str")
             make_pyeval(x.args[3:end]...), false

--- a/src/julia/pyjulia_helper.jl
+++ b/src/julia/pyjulia_helper.jl
@@ -61,7 +61,7 @@ macro prepare_for_pyjulia_call(ex)
     locals = gensym("locals")
     globals = gensym("globals")
     
-    function make_pyeval(expr, options...)
+    function make_pyeval(expr::Union{String,Symbol}, options...)
         code = string(expr)
         T = length(options) == 1 && 'o' in options[1] ? PyObject : PyAny
         input_type = '\n' in code ? Py_file_input : Py_eval_input

--- a/src/julia/pyjulia_helper.jl
+++ b/src/julia/pyjulia_helper.jl
@@ -81,11 +81,14 @@ macro prepare_for_pyjulia_call(ex)
                 """)
             end
         elseif isexpr(x, :macrocall) && x.args[1]==Symbol("@py_str")
-            make_pyeval(x.args[3:end]...), false
+            # in Julia 0.7+, x.args[2] is a LineNumberNode, so filter it out
+            # in a way that's compatible with Julia 0.6:
+            make_pyeval(filter(s->(s isa String), x.args[2:end])...), false
         else
             x, true
         end 
     end
+    
     esc(quote
         $pyfunction(($globals,$locals) -> (@eval Main $ex), $PyObject, $PyObject)
     end)

--- a/src/julia/pyjulia_helper.jl
+++ b/src/julia/pyjulia_helper.jl
@@ -66,7 +66,7 @@ macro prepare_for_pyjulia_call(ex)
         code = string(expr)
         T = length(options) == 1 && 'o' in options[1] ? PyObject : PyAny
         input_type = '\n' in code ? Py_file_input : Py_eval_input
-        :($convert($T, $pyeval_($code, $globals, $locals, $input_type)))
+        :($convert($T, $pyeval_($code, $(Expr(:$,globals)), $(Expr(:$,locals)), $input_type)))
     end
         
     ex = walk(ex) do x
@@ -83,7 +83,7 @@ macro prepare_for_pyjulia_call(ex)
         end 
     end
     esc(quote
-        $pyfunction(($globals,$locals) -> $ex, $PyObject, $PyObject)
+        $pyfunction(($globals,$locals) -> (@eval Main $ex), $PyObject, $PyObject)
     end)
 end
 

--- a/test/test_magic.py
+++ b/test/test_magic.py
@@ -77,18 +77,33 @@ def test_bad_interp(run_cell):
         """)
 
 def test_string_interp(run_cell):
+    run_cell("foo='python'")
     assert run_cell("""
     %%julia 
-    foo=3
-    "$foo"
-    """) == '3'
+    foo="julia"
+    "$foo", "$($foo)"
+    """) == ('julia','python')
 
-def test_interp_escape(run_cell):
+def test_expr_interp(run_cell):
+    run_cell("foo='python'")
+    assert run_cell("""
+    %%julia 
+    foo="julia"
+    :($foo), :($($foo))
+    """) == ('julia','python')
+    
+def test_expr_py_interp(run_cell):
+    assert "baz" in str(run_cell("""
+    %julia :(py"baz")
+    """))
+    
+def test_macro_esc(run_cell):
     assert run_cell("""
     %%julia
-    bar=3
-    :($$bar)
-    """) == 3
+    x = 1
+    @eval y = $x
+    y
+    """) == 1
 
 def test_type_conversion(run_cell):
     assert run_cell("""

--- a/test/test_magic.py
+++ b/test/test_magic.py
@@ -98,7 +98,7 @@ def test_interp_escape(julia_magics):
 
 def test_type_conversion(julia_magics):
     assert julia_magics.run_cell("""
-    %julia py"1" isa Int && py"1"o isa PyObject
+    %julia py"1" isa Integer && py"1"o isa PyObject
     """) == True
 
 def test_scoping(julia_magics):

--- a/test/test_magic.py
+++ b/test/test_magic.py
@@ -1,14 +1,36 @@
-from IPython.testing.globalipapp import start_ipython as _start_ipython
-from IPython import get_ipython as _get_ipython
-from julia import magic
+from textwrap import dedent
+
 import pytest
+from IPython import get_ipython as _get_ipython
+from IPython.testing.globalipapp import start_ipython as _start_ipython
+
+from julia import magic
+
 
 def get_ipython():
     return _start_ipython() or _get_ipython()
 
 @pytest.fixture
 def julia_magics(julia):
-    return magic.JuliaMagics(shell=get_ipython())
+    julia_magics = magic.JuliaMagics(shell=get_ipython())
+    
+    # a more conenient way to run strings (possibly with magic) as if they were
+    # an IPython cell
+    def run_cell(self, cell):
+        cell = dedent(cell).strip()
+        if cell.startswith("%%"):
+            return self.shell.run_cell_magic("julia","",cell.replace("%%julia","").strip())
+        else:
+            exec_result = self.shell.run_cell(cell)
+            if exec_result.error_in_exec:
+                raise exec_result.error_in_exec
+            else:
+                return exec_result.result
+                
+    julia_magics.run_cell = run_cell.__get__(julia_magics, julia_magics.__class__)
+    
+    return julia_magics
+
 
 
 def test_register_magics(julia):
@@ -35,48 +57,60 @@ def test_failure_cell(julia_magics):
         julia_magics.julia(None, '1 += 1')
 
 
+# Prior to IPython 7.3, $x did a string interpolation handled by IPython itself
+# for *line* magic, and could not be turned off. However, even prior to
+# IPython 7.3, *cell* magic never did the string interpolation, so below, any
+# time we need to test $x interpolation, do it as cell magic so it works on
+# IPython < 7.3
+
 def test_interp_var(julia_magics):
-    assert julia_magics.shell.run_cell("""
-    x=1
-    %julia $x
-    """).result == 1
+    julia_magics.run_cell("x=1")
+    assert julia_magics.run_cell("""
+    %%julia
+    $x
+    """) == 1
     
 def test_interp_expr(julia_magics):
-    assert julia_magics.shell.run_cell("""
+    assert julia_magics.run_cell("""
     x=1
     %julia py"x+1"
-    """).result == 2
-    
+    """) == 2
+
 def test_bad_interp(julia_magics):
-    assert julia_magics.shell.run_cell("""
-    %julia $(x+1)
-    """).error_in_exec is not None
-    
+    with pytest.raises(Exception):
+        assert julia_magics.run_cell("""
+        %julia $(x+1)
+        """)
+
 def test_string_interp(julia_magics):
-    assert julia_magics.shell.run_cell("""
-    %julia foo=3; "$foo"    
-    """).result == '3'
-    
+    assert julia_magics.run_cell("""
+    %%julia 
+    foo=3
+    "$foo"
+    """) == '3'
+
 def test_interp_escape(julia_magics):
-    assert julia_magics.shell.run_cell("""
-    %julia bar=3; :($$bar)
-    """).result == 3
-    
+    assert julia_magics.run_cell("""
+    %%julia
+    bar=3
+    :($$bar)
+    """) == 3
+
 def test_type_conversion(julia_magics):
-    assert julia_magics.shell.run_cell("""
+    assert julia_magics.run_cell("""
     %julia py"1" isa Int && py"1"o isa PyObject
-    """).result == True
-    
+    """) == True
+
 def test_scoping(julia_magics):
-    assert julia_magics.shell.run_cell("""
+    assert julia_magics.run_cell("""
     x = "global"
     def f():
         x = "local"
         ret = %julia py"x"
         return ret
     f()    
-    """).result == "local"
-    
+    """) == "local"
+
 def test_revise_error():
     from julia.ipy import revise
 


### PR DESCRIPTION
From the docs included in this PR:


Python variables can be passed to Julia using either `$foo` or `{foo}`.  

```none
In [3]: foo = [[1,2],[3,4]]

In [4]: %julia $foo .+ 1
Out[4]: 
array([[2, 3],
       [4, 5]], dtype=int64)
```

The `{}` style supports passing arbitrary Python expressions inside.

```none
In [5]: %julia {[x for x in range(3)]}
Out[5]: array([0, 1, 2], dtype=int64)
```


Variables are automatically converted between equivalent Python/Julia types (should they exist) using PyCall. Note below that `1`, `x`, and the tuple itself are converted to Julia `Int64`, `String`, and `Tuple`, respectively, although the function `abs` and the result of `typeof` are not.

```none
In [6]: %julia typeof({(1,"x",abs)})
Out[6]: <PyCall.jlwrap Tuple{Int64,String,PyObject}>
```


Closes https://github.com/JuliaPy/pyjulia/issues/205

Happy to take any feedback or requests for changes. I didn't write any tests since I couldn't figure out how to make pytest work with python-jl (which my system needs) so maybe someone could help with creating tests, perhaps in a separate PR? (there we'll need to figure out how testing interacts with the fact that interpolation is using the IPython shell global namespace)