### PR TITLE
RFC: Use black code style

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,10 @@
+[settings]
+known_first_party = julia
+default_section = THIRDPARTY
+
+# Black-compatible setting.  See: https://github.com/ambv/black
+multi_line_output = 3
+include_trailing_comma = True
+force_grid_wrap = 0
+use_parentheses = True
+line_length = 88

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: https://github.com/ambv/black
+    rev: 19.3b0
+    hooks:
+    - id: black
+    # See:
+    # * https://black.readthedocs.io/en/stable/version_control_integration.html
+    # * https://github.com/ambv/black/blob/master/.pre-commit-hooks.yaml

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,8 @@
 repos:
+-   repo: https://github.com/pre-commit/mirrors-isort
+    rev: v4.3.17
+    hooks:
+    -   id: isort
 -   repo: https://github.com/ambv/black
     rev: 19.3b0
     hooks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,17 @@ env:
 matrix:
   # Python environment is not functional on OS X
   include:
+      - language: python
+        env:
+          - TOXENV=style
+        os: linux
+        python: "3.6"
+        before_script:
+          - python -m pip --version
+          - python -m pip install --quiet tox
+        script:
+          - python -m tox
+        after_success: []
       - language: generic
         env:
           - PYTHON=python2

--- a/ci/install_pycall.py
+++ b/ci/install_pycall.py
@@ -5,6 +5,6 @@ sys.path.insert(
     0, os.path.join(os.path.dirname(os.path.realpath(__file__)), os.path.pardir, "src")
 )
 
-import julia
+import julia  # isort:skip
 
 julia.install(color=True)

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -18,6 +18,7 @@
 
 
 # -- Project information -----------------------------------------------------
+# fmt: off
 
 project = 'PyJulia'
 copyright = '2019, The Julia and IPython development teams'

--- a/setup.py
+++ b/setup.py
@@ -11,12 +11,14 @@ def pyload(name):
         exec(compile(f.read(), name, "exec"), ns)
     return ns
 
+
 # In case it's Python 2:
 try:
     execfile
 except NameError:
     pass
 else:
+
     def pyload(path):
         ns = {}
         execfile(path, ns)
@@ -32,6 +34,7 @@ with open(os.path.join(repo_root, "README.md"), encoding="utf-8") as f:
 ns = pyload(os.path.join(repo_root, "src", "julia", "release.py"))
 version = ns["__version__"]
 
+# fmt: off
 setup(name='julia',
       version=version,
       description="Julia/Python bridge with IPython support.",

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python
 
-from io import open  # for Python 2 (identical to builtin in Python 3)
-from setuptools import setup, find_packages
 import os
+from io import open  # for Python 2 (identical to builtin in Python 3)
+
+from setuptools import find_packages, setup
 
 
 def pyload(name):

--- a/src/julia/__init__.py
+++ b/src/julia/__init__.py
@@ -1,4 +1,5 @@
+from .core import JuliaError
+from .core import LegacyJulia as Julia
+from .ipy.revise import disable_revise, enable_revise
 from .release import __version__
-from .core import JuliaError, LegacyJulia as Julia
-from .ipy.revise import enable_revise, disable_revise
 from .tools import install

--- a/src/julia/api.py
+++ b/src/julia/api.py
@@ -1,1 +1,1 @@
-from .core import Julia, JuliaError, LibJulia, JuliaInfo
+from .core import Julia, JuliaError, JuliaInfo, LibJulia

--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -13,7 +13,6 @@ Bridge Python and Julia by initializing the Julia runtime inside Python.
 # Imports
 # ----------------------------------------------------------------------------
 
-# Stdlib
 from __future__ import print_function, absolute_import
 
 from logging import getLogger  # see `.logger`
@@ -45,9 +44,7 @@ except ImportError:
         b = os.path.realpath(os.path.normcase(f2))
         return a == b
 
-
-# this is python 3.3 specific
-from types import ModuleType
+from types import ModuleType  # this is python 3.3 specific
 
 from .find_libpython import find_libpython, linked_libpython
 from .options import JuliaOptions, options_docs, parse_jl_options

--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -27,9 +27,7 @@ import subprocess
 import textwrap
 import warnings
 
-from ctypes import c_void_p as void_p
-from ctypes import c_char_p as char_p
-from ctypes import py_object, c_int, c_char_p, POINTER, pointer
+from ctypes import py_object, c_char_p, c_int, c_void_p, POINTER, pointer
 
 try:
     from shutil import which
@@ -510,40 +508,40 @@ def is_compatible_exe(jl_libpython):
 
 def setup_libjulia(libjulia):
     # Store the running interpreter reference so we can start using it via self.call
-    libjulia.jl_.argtypes = [void_p]
+    libjulia.jl_.argtypes = [c_void_p]
     libjulia.jl_.restype = None
 
     # Set the return types of some of the bridge functions in ctypes terminology
-    libjulia.jl_eval_string.argtypes = [char_p]
-    libjulia.jl_eval_string.restype = void_p
+    libjulia.jl_eval_string.argtypes = [c_char_p]
+    libjulia.jl_eval_string.restype = c_void_p
 
-    libjulia.jl_exception_occurred.restype = void_p
-    libjulia.jl_typeof_str.argtypes = [void_p]
-    libjulia.jl_typeof_str.restype = char_p
-    libjulia.jl_call2.argtypes = [void_p, void_p, void_p]
-    libjulia.jl_call2.restype = void_p
-    libjulia.jl_get_field.argtypes = [void_p, char_p]
-    libjulia.jl_get_field.restype = void_p
-    libjulia.jl_typename_str.restype = char_p
-    libjulia.jl_unbox_voidpointer.argtypes = [void_p]
+    libjulia.jl_exception_occurred.restype = c_void_p
+    libjulia.jl_typeof_str.argtypes = [c_void_p]
+    libjulia.jl_typeof_str.restype = c_char_p
+    libjulia.jl_call2.argtypes = [c_void_p, c_void_p, c_void_p]
+    libjulia.jl_call2.restype = c_void_p
+    libjulia.jl_get_field.argtypes = [c_void_p, c_char_p]
+    libjulia.jl_get_field.restype = c_void_p
+    libjulia.jl_typename_str.restype = c_char_p
+    libjulia.jl_unbox_voidpointer.argtypes = [c_void_p]
     libjulia.jl_unbox_voidpointer.restype = py_object
 
     for c_type in UNBOXABLE_TYPES:
         jl_unbox = getattr(libjulia, "jl_unbox_{}".format(c_type))
-        jl_unbox.argtypes = [void_p]
+        jl_unbox.argtypes = [c_void_p]
         jl_unbox.restype = getattr(ctypes, "c_{}".format({
             "float32": "float",
             "float64": "double",
         }.get(c_type, c_type)))
 
-    libjulia.jl_typeof.argtypes = [void_p]
-    libjulia.jl_typeof.restype = void_p
+    libjulia.jl_typeof.argtypes = [c_void_p]
+    libjulia.jl_typeof.restype = c_void_p
 
     libjulia.jl_exception_clear.restype = None
     libjulia.jl_stderr_obj.argtypes = []
-    libjulia.jl_stderr_obj.restype = void_p
+    libjulia.jl_stderr_obj.restype = c_void_p
     libjulia.jl_stderr_stream.argtypes = []
-    libjulia.jl_stderr_stream.restype = void_p
+    libjulia.jl_stderr_stream.restype = c_void_p
     libjulia.jl_printf.restype = ctypes.c_int
 
     libjulia.jl_parse_opts.argtypes = [POINTER(c_int),
@@ -759,7 +757,7 @@ class LibJulia(BaseLibJulia):
                 argv_list = [s.encode('utf-8') for s in argv_list]
 
             argc = c_int(len(argv_list))
-            argv = POINTER(char_p)((char_p * len(argv_list))(*argv_list))
+            argv = POINTER(c_char_p)((c_char_p * len(argv_list))(*argv_list))
 
             logger.debug("argv_list = %r", argv_list)
             logger.debug("argc = %r", argc)
@@ -1139,9 +1137,9 @@ class Julia(object):
                          .format(exception, src))
 
     def _typeof_julia_exception_in_transit(self):
-        exception = void_p.in_dll(self.api, 'jl_exception_in_transit')
+        exception = c_void_p.in_dll(self.api, 'jl_exception_in_transit')
         msg = self.api.jl_typeof_str(exception)
-        return char_p(msg).value
+        return c_char_p(msg).value
 
     def help(self, name):
         """ Return help string for function by name. """

--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -2,21 +2,22 @@
 Bridge Python and Julia by initializing the Julia runtime inside Python.
 """
 
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Copyright (C) 2013 The IPython and Julia Development Teams.
 #
 # Distributed under the terms of the BSD License. The full license is in
 # the file COPYING, distributed as part of this software.
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Imports
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 # Stdlib
 from __future__ import print_function, absolute_import
 
 from logging import getLogger
+
 # Not importing `logging` module here so that using `logging.debug`
 # instead of `logger.debug` becomes an error.
 
@@ -63,9 +64,9 @@ try:
 except NameError:
     string_types = (str,)
 
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Classes and funtions
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 python_version = sys.version_info
 
 
@@ -113,6 +114,9 @@ class JuliaError(Exception):
     """
     Wrapper for Julia exceptions.
     """
+
+
+# fmt: off
 
 
 class JuliaNotFound(RuntimeError):

--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -16,10 +16,7 @@ Bridge Python and Julia by initializing the Julia runtime inside Python.
 # Stdlib
 from __future__ import print_function, absolute_import
 
-from logging import getLogger
-
-# Not importing `logging` module here so that using `logging.debug`
-# instead of `logger.debug` becomes an error.
+from logging import getLogger  # see `.logger`
 
 import atexit
 import ctypes
@@ -71,6 +68,12 @@ python_version = sys.version_info
 
 
 logger = getLogger("julia")
+"""
+Implementation notes: We are not importing `logging` module at the top
+level so that using `logging.debug` instead of `logger.debug` becomes
+an error.
+"""
+
 _loghandler = None
 
 
@@ -80,7 +83,7 @@ def get_loghandler():
     """
     global _loghandler
     if _loghandler is None:
-        import logging
+        import logging  # see `.logger`
 
         formatter = logging.Formatter("%(levelname)s %(message)s")
 
@@ -92,7 +95,7 @@ def get_loghandler():
 
 
 def set_loglevel(level):
-    import logging
+    import logging  # see `.logger`
 
     get_loghandler()
     logger.setLevel(getattr(logging, level, level))

--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -13,20 +13,24 @@ Bridge Python and Julia by initializing the Julia runtime inside Python.
 # Imports
 # ----------------------------------------------------------------------------
 
-from __future__ import print_function, absolute_import
-
-from logging import getLogger  # see `.logger`
+from __future__ import absolute_import, print_function
 
 import atexit
 import ctypes
 import ctypes.util
 import os
-import sys
 import subprocess
+import sys
 import textwrap
 import warnings
+from ctypes import POINTER, c_char_p, c_int, c_void_p, pointer, py_object
+from logging import getLogger  # see `.logger`
+from types import ModuleType  # this is python 3.3 specific
 
-from ctypes import py_object, c_char_p, c_int, c_void_p, POINTER, pointer
+from .find_libpython import find_libpython, linked_libpython
+from .options import JuliaOptions, options_docs, parse_jl_options
+from .release import __version__
+from .utils import is_windows
 
 try:
     from shutil import which
@@ -44,12 +48,6 @@ except ImportError:
         b = os.path.realpath(os.path.normcase(f2))
         return a == b
 
-from types import ModuleType  # this is python 3.3 specific
-
-from .find_libpython import find_libpython, linked_libpython
-from .options import JuliaOptions, options_docs, parse_jl_options
-from .release import __version__
-from .utils import is_windows
 
 try:
     string_types = (basestring,)

--- a/src/julia/fake-julia/julia.py
+++ b/src/julia/fake-julia/julia.py
@@ -1,9 +1,10 @@
 # Minimal repl.c to support precompilation with python symbols already loaded
 # fmt: off
 import ctypes
-import sys
 import os
+import sys
 from ctypes import *
+
 if sys.platform.startswith('darwin'):
     sh_ext = ".dylib"
 elif sys.platform.startswith('win32'):

--- a/src/julia/fake-julia/julia.py
+++ b/src/julia/fake-julia/julia.py
@@ -1,4 +1,5 @@
 # Minimal repl.c to support precompilation with python symbols already loaded
+# fmt: off
 import ctypes
 import sys
 import os

--- a/src/julia/find_libpython.py
+++ b/src/julia/find_libpython.py
@@ -29,7 +29,7 @@ Locate libpython associated with this Python executable.
 
 from __future__ import print_function, absolute_import
 
-from logging import getLogger
+from logging import getLogger  # see `julia.core.logger`
 import ctypes.util
 import functools
 import os

--- a/src/julia/find_libpython.py
+++ b/src/julia/find_libpython.py
@@ -27,14 +27,14 @@ Locate libpython associated with this Python executable.
 # OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 # WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
-from logging import getLogger  # see `julia.core.logger`
 import ctypes.util
 import functools
 import os
 import sys
 import sysconfig
+from logging import getLogger  # see `julia.core.logger`
 
 logger = getLogger("find_libpython")
 

--- a/src/julia/find_libpython.py
+++ b/src/julia/find_libpython.py
@@ -76,6 +76,9 @@ class Dl_info(ctypes.Structure):
     ]
 
 
+# fmt: off
+
+
 def _linked_libpython_unix():
     libdl = ctypes.CDLL(ctypes.util.find_library("dl"))
     libdl.dladdr.argtypes = [ctypes.c_void_p, ctypes.POINTER(Dl_info)]

--- a/src/julia/ipy/monkeypatch_completer.py
+++ b/src/julia/ipy/monkeypatch_completer.py
@@ -6,7 +6,7 @@ immediate plan for an API to do this:
 https://github.com/ipython/ipython/pull/10722
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import re
 

--- a/src/julia/ipy/monkeypatch_interactiveshell.py
+++ b/src/julia/ipy/monkeypatch_interactiveshell.py
@@ -2,7 +2,7 @@
 Monkey-patch `TerminalInteractiveShell` to highlight code in ``%%julia``.
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 from IPython.terminal.interactiveshell import TerminalInteractiveShell
 from prompt_toolkit.lexers import PygmentsLexer

--- a/src/julia/ipy/revise.py
+++ b/src/julia/ipy/revise.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import warnings
 

--- a/src/julia/julia_py.py
+++ b/src/julia/julia_py.py
@@ -12,14 +12,14 @@ Example::
     $ julia-py --sysimage sys.so
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import argparse
 import os
 import sys
 
 from .api import LibJulia
-from .core import which, enable_debug
+from .core import enable_debug, which
 from .tools import julia_py_executable
 
 

--- a/src/julia/magic.py
+++ b/src/julia/magic.py
@@ -13,9 +13,9 @@ Usage
 {JULIA_DOC}
 """
 
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # Imports
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 from __future__ import print_function, absolute_import
 
@@ -32,12 +32,14 @@ from .tools import redirect_output_streams
 try:
     from IPython.core.magic import no_var_expand
 except ImportError:
+
     def no_var_expand(f):
         return f
 
-#-----------------------------------------------------------------------------
+
+# ----------------------------------------------------------------------------
 # Main classes
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 
 @magics_class
@@ -88,8 +90,7 @@ class JuliaMagics(Magics):
         """
 
         super(JuliaMagics, self).__init__(shell)
-        print("Initializing Julia runtime. This may take some time...",
-              end='')
+        print("Initializing Julia interpreter. This may take some time...", end="")
         # Flush, otherwise the Julia startup will keep stdout buffered
         sys.stdout.flush()
         self._julia = Julia(init_julia=True)
@@ -104,6 +105,8 @@ class JuliaMagics(Magics):
         """
         src = compat.unicode_type(line if cell is None else cell)
 
+        # fmt: off
+
         # We assume the caller's frame is the first parent frame not in the
         # IPython module. This seems to work with IPython back to ~v5, and
         # is at least somewhat immune to future IPython internals changes,
@@ -116,10 +119,13 @@ class JuliaMagics(Magics):
         _PyJuliaHelper.@prepare_for_pyjulia_call begin %s end
         """%src)(self.shell.user_ns, caller_frame.f_locals)
 
+        # fmt: on
+
+
 # Add to the global docstring the class information.
 __doc__ = __doc__.format(
-    JULIAMAGICS_DOC=' ' * 8 + JuliaMagics.__doc__,
-    JULIA_DOC=' ' * 8 + JuliaMagics.julia.__doc__,
+    JULIAMAGICS_DOC=" " * 8 + JuliaMagics.__doc__,
+    JULIA_DOC=" " * 8 + JuliaMagics.julia.__doc__,
 )
 
 
@@ -131,9 +137,9 @@ def should_redirect_output_streams():
     return isinstance(sys.stdout, OutStream)
 
 
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 # IPython registration entry point.
-#-----------------------------------------------------------------------------
+# ----------------------------------------------------------------------------
 
 
 def load_ipython_extension(ip):

--- a/src/julia/magic.py
+++ b/src/julia/magic.py
@@ -17,12 +17,12 @@ Usage
 # Imports
 # ----------------------------------------------------------------------------
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import sys
 import warnings
 
-from IPython.core.magic import Magics, magics_class, line_cell_magic
+from IPython.core.magic import Magics, line_cell_magic, magics_class
 from IPython.utils import py3compat as compat
 from traitlets import Bool, Enum
 

--- a/src/julia/options.py
+++ b/src/julia/options.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import textwrap
 

--- a/src/julia/pseudo_python_cli.py
+++ b/src/julia/pseudo_python_cli.py
@@ -51,17 +51,12 @@ def python(module, command, script, args, interactive):
             scope = {}
             exec(command, scope)
         elif module:
-            scope = runpy.run_module(
-                module,
-                run_name="__main__",
-                alter_sys=True)
+            scope = runpy.run_module(module, run_name="__main__", alter_sys=True)
         elif script == "-":
             source = sys.stdin.read()
             exec(compile(source, "<stdin>", "exec"), scope)
         elif script:
-            scope = runpy.run_path(
-                script,
-                run_name="__main__")
+            scope = runpy.run_path(script, run_name="__main__")
         else:
             interactive = True
             scope = None
@@ -73,6 +68,7 @@ def python(module, command, script, args, interactive):
 
     if interactive:
         code.interact(banner=banner, local=scope)
+
 
 ArgDest = namedtuple("ArgDest", "dest names default")
 Optional = namedtuple("Optional", "name is_long argdest nargs action terminal")
@@ -94,8 +90,7 @@ class PyArgumentParser(object):
       to stop parsing after consuming the given option.
     """
 
-    def __init__(self, prog=None, usage="%(prog)s [options] [args]",
-                 description=""):
+    def __init__(self, prog=None, usage="%(prog)s [options] [args]", description=""):
         self.prog = sys.argv[0] if prog is None else prog
         self.usage = usage
         self.description = description
@@ -117,6 +112,8 @@ class PyArgumentParser(object):
 
     def add_argument(self, name, *alt, **kwargs):
         return self._add_argument_impl(name, alt, **kwargs)
+
+    # fmt: off
 
     def _add_argument_impl(self, name, alt, dest=None, nargs=None, action=None,
                            default=None, terminal=False):
@@ -243,6 +240,7 @@ class PyArgumentParser(object):
                         return results
                         # arg="-ih" -> rest="-h"
         return []
+    # fmt: on
 
     def print_usage(self, file=None):
         print(self.format_usage(), file=file or sys.stdout)
@@ -269,7 +267,8 @@ def make_parser(description=__doc__ + ARGUMENT_HELP):
     parser = PyArgumentParser(
         prog=None if sys.argv[0] else "python",
         usage="%(prog)s [option] ... [-c cmd | -m mod | script | -] [args]",
-        description=description)
+        description=description,
+    )
 
     parser.add_argument("-i", dest="interactive", action="store_true")
     parser.add_argument("--version", "-V", action="store_true")

--- a/src/julia/pseudo_python_cli.py
+++ b/src/julia/pseudo_python_cli.py
@@ -5,14 +5,14 @@ It tries to mimic a subset of Python CLI:
 https://docs.python.org/3/using/cmdline.html
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
-from collections import namedtuple
 import code
 import copy
 import runpy
 import sys
 import traceback
+from collections import namedtuple
 
 try:
     from types import SimpleNamespace

--- a/src/julia/pytestplugin.py
+++ b/src/julia/pytestplugin.py
@@ -1,4 +1,4 @@
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import sys
 

--- a/src/julia/python_jl.py
+++ b/src/julia/python_jl.py
@@ -26,9 +26,12 @@ import sys
 from .pseudo_python_cli import make_parser, parse_args_with, ARGUMENT_HELP
 from .utils import execprog
 
-PYJL_ARGUMENT_HELP = ARGUMENT_HELP + """
+PYJL_ARGUMENT_HELP = (
+    ARGUMENT_HELP
+    + """
   --julia JULIA  Julia runtime to be used. (default: julia)
 """
+)
 
 script_jl = """
 import PyCall

--- a/src/julia/python_jl.py
+++ b/src/julia/python_jl.py
@@ -19,11 +19,11 @@ by::
    configured has to have PyJulia installed.
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import sys
 
-from .pseudo_python_cli import make_parser, parse_args_with, ARGUMENT_HELP
+from .pseudo_python_cli import ARGUMENT_HELP, make_parser, parse_args_with
 from .utils import execprog
 
 PYJL_ARGUMENT_HELP = (

--- a/src/julia/runtests.py
+++ b/src/julia/runtests.py
@@ -2,7 +2,7 @@
 Run tests for PyJulia.
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import argparse
 import sys

--- a/src/julia/sysimage.py
+++ b/src/julia/sysimage.py
@@ -13,20 +13,19 @@ Generated system image can be passed to ``sysimage`` option of
    This script is not tested on Windows.
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
-from contextlib import contextmanager
-from logging import getLogger  # see `.core.logger`
 import argparse
 import os
+import shutil
 import subprocess
 import sys
-import shutil
 import tempfile
+from contextlib import contextmanager
+from logging import getLogger  # see `.core.logger`
 
 from .core import enable_debug
 from .tools import julia_py_executable
-
 
 logger = getLogger("julia.sysimage")
 

--- a/src/julia/sysimage.py
+++ b/src/julia/sysimage.py
@@ -16,7 +16,7 @@ Generated system image can be passed to ``sysimage`` option of
 from __future__ import print_function, absolute_import
 
 from contextlib import contextmanager
-from logging import getLogger
+from logging import getLogger  # see `.core.logger`
 import argparse
 import os
 import subprocess

--- a/src/julia/tests/test_compatible_exe.py
+++ b/src/julia/tests/test_compatible_exe.py
@@ -8,8 +8,9 @@ import tempfile
 import textwrap
 from contextlib import contextmanager
 
-import julia
 import pytest
+
+import julia
 from julia.core import _enviorn, which
 
 is_linux = sys.platform.startswith("linux")

--- a/src/julia/tests/test_core.py
+++ b/src/julia/tests/test_core.py
@@ -3,13 +3,14 @@ from __future__ import print_function
 import array
 import math
 import subprocess
+import sys
 from types import ModuleType
 
-from julia import JuliaError
-from julia.core import jl_name, py_name, _enviorn as orig_env
-import sys
-
 import pytest
+
+from julia import JuliaError
+from julia.core import _enviorn as orig_env
+from julia.core import jl_name, py_name
 
 python_version = sys.version_info
 

--- a/src/julia/tests/test_find_libpython.py
+++ b/src/julia/tests/test_find_libpython.py
@@ -12,13 +12,15 @@ except NameError:
 def test_finding_libpython_yield_type():
     paths = list(finding_libpython())
     assert set(map(type, paths)) <= {str, unicode}
+
+
 # In a statically linked Python executable, no paths may be found.  So
 # let's just check returned type of finding_libpython.
 
 
 def determine_if_statically_linked():
     """Determines if this python executable is statically linked"""
-    if not sys.platform.startswith('linux'):
+    if not sys.platform.startswith("linux"):
         # Assuming that Windows and OS X are generally always
         # dynamically linked.  Note that this is not the case in
         # Python installed via conda:

--- a/src/julia/tests/test_install.py
+++ b/src/julia/tests/test_install.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 
 import pytest
+
 from julia import install
 
 from .utils import only_in_ci

--- a/src/julia/tests/test_juliainfo.py
+++ b/src/julia/tests/test_juliainfo.py
@@ -48,7 +48,11 @@ def test_juliainfo_without_pycall(tmpdir):
     runtime = os.getenv("PYJULIA_TEST_RUNTIME", "julia")
 
     env_var = subprocess.check_output(
-        [runtime, "--startup-file=no", "-e", """
+        [
+            runtime,
+            "--startup-file=no",
+            "-e",
+            """
         if VERSION < v"0.7-"
             println("JULIA_PKGDIR")
             print(ARGS[1])
@@ -57,14 +61,15 @@ def test_juliainfo_without_pycall(tmpdir):
             println("JULIA_DEPOT_PATH")
             print(join(paths, Sys.iswindows() ? ';' : ':'))
         end
-        """, str(tmpdir)],
+        """,
+            str(tmpdir),
+        ],
         env=_enviorn,
-        universal_newlines=True)
+        universal_newlines=True,
+    )
     name, val = env_var.split("\n", 1)
 
-    jlinfo = JuliaInfo.load(
-        runtime,
-        env=dict(_enviorn, **{name: val}))
+    jlinfo = JuliaInfo.load(runtime, env=dict(_enviorn, **{name: val}))
 
     check_core_juliainfo(jlinfo)
     assert jlinfo.python is None
@@ -73,9 +78,7 @@ def test_juliainfo_without_pycall(tmpdir):
     assert not jlinfo.is_compatible_python()
 
 
-@pytest.mark.skipif(
-    not which("false"),
-    reason="false command not found")
+@pytest.mark.skipif(not which("false"), reason="false command not found")
 def test_juliainfo_failure():
     with pytest.raises(subprocess.CalledProcessError) as excinfo:
         JuliaInfo.load(julia="false")

--- a/src/julia/tests/test_juliaoptions.py
+++ b/src/julia/tests/test_juliaoptions.py
@@ -3,6 +3,7 @@ import pytest
 from julia.core import JuliaOptions
 
 
+# fmt: off
 @pytest.mark.parametrize("kwargs, args", [
     ({}, []),
     (dict(compiled_modules=None), []),
@@ -12,6 +13,7 @@ from julia.core import JuliaOptions
     (dict(sysimage="PATH"), ["--sysimage", "PATH"]),
     (dict(bindir="PATH"), ["--home", "PATH"]),
 ])
+# fmt: on
 def test_as_args(kwargs, args):
     assert JuliaOptions(**kwargs).as_args() == args
 
@@ -27,10 +29,12 @@ def test_valueerror(kwargs):
     assert "accept" in str(excinfo.value)
 
 
+# fmt: off
 @pytest.mark.parametrize("kwargs", [
     dict(invalid_option=None),
     dict(invalid_option_1=None, invalid_option_2=None),
 ])
+# fmt: on
 def test_unsupported(kwargs):
     with pytest.raises(TypeError) as excinfo:
         JuliaOptions(**kwargs)

--- a/src/julia/tests/test_libjulia.py
+++ b/src/julia/tests/test_libjulia.py
@@ -1,7 +1,8 @@
 import pytest
 
-from .test_compatible_exe import runcode
 from julia.core import JuliaInfo
+
+from .test_compatible_exe import runcode
 
 juliainfo = JuliaInfo.load()
 

--- a/src/julia/tests/test_magic.py
+++ b/src/julia/tests/test_magic.py
@@ -11,6 +11,9 @@ def julia_magics(julia):
     return magic.JuliaMagics(shell=globalipapp.get_ipython())
 
 
+# fmt: off
+
+
 @pytest.fixture
 def run_cell(julia_magics):
     # a more convenient way to run strings (possibly with magic) as if they were

--- a/src/julia/tests/test_plugin.py
+++ b/src/julia/tests/test_plugin.py
@@ -1,6 +1,5 @@
 from julia.core import which
 
-
 pytest_plugins = ["pytester"]
 
 

--- a/src/julia/tests/test_pseudo_python_cli.py
+++ b/src/julia/tests/test_pseudo_python_cli.py
@@ -10,6 +10,7 @@ def make_dict(**kwargs):
     return dict(vars(ns), **kwargs)
 
 
+# fmt: off
 @pytest.mark.parametrize("args, desired", [
     ("-m json.tool -h", make_dict(module="json.tool", args=["-h"])),
     ("-mjson.tool -h", make_dict(module="json.tool", args=["-h"])),
@@ -30,12 +31,14 @@ def make_dict(**kwargs):
     ("script -c 1", make_dict(script="script", args=["-c", "1"])),
     ("script -h 1", make_dict(script="script", args=["-h", "1"])),
 ])
+# fmt: on
 def test_valid_args(args, desired):
     ns = parse_args(shlex.split(args))
     actual = vars(ns)
     assert actual == desired
 
 
+# fmt: off
 @pytest.mark.parametrize("args", [
     "-m",
     "-c",
@@ -43,6 +46,7 @@ def test_valid_args(args, desired):
     "-h -m",
     "-V -m",
 ])
+# fmt: on
 def test_invalid_args(args, capsys):
     with pytest.raises(SystemExit) as exc_info:
         parse_args(shlex.split(args))
@@ -53,6 +57,7 @@ def test_invalid_args(args, capsys):
     assert not captured.out
 
 
+# fmt: off
 @pytest.mark.parametrize("args", [
     "-h",
     "-i --help",
@@ -64,6 +69,7 @@ def test_invalid_args(args, capsys):
     "-h -m json.tool",
     "-h -mjson.tool",
 ])
+# fmt: on
 def test_help_option(args, capsys):
     with pytest.raises(SystemExit) as exc_info:
         parse_args(shlex.split(args))
@@ -74,6 +80,7 @@ def test_help_option(args, capsys):
     assert not captured.err
 
 
+# fmt: off
 @pytest.mark.parametrize("args", [
     "-V",
     "--version",
@@ -83,6 +90,7 @@ def test_help_option(args, capsys):
     "-V script",
     "-V script -h",
 ])
+# fmt: on
 def test_version_option(args, capsys):
     with pytest.raises(SystemExit) as exc_info:
         parse_args(shlex.split(args))

--- a/src/julia/tests/test_python_jl.py
+++ b/src/julia/tests/test_python_jl.py
@@ -16,6 +16,8 @@ python_jl_required = pytest.mark.skipif(
     reason="python-jl command not found",
 )
 
+# fmt: off
+
 
 @pytest.mark.parametrize("args", [
     "-h",

--- a/src/julia/tests/test_python_jl.py
+++ b/src/julia/tests/test_python_jl.py
@@ -1,7 +1,7 @@
-from textwrap import dedent
 import os
 import shlex
 import subprocess
+from textwrap import dedent
 
 import pytest
 

--- a/src/julia/tests/test_sysimage.py
+++ b/src/julia/tests/test_sysimage.py
@@ -1,8 +1,9 @@
 import pytest
 
+from julia.sysimage import build_sysimage
+
 from .test_compatible_exe import runcode
 from .utils import only_in_ci, skip_in_appveyor
-from julia.sysimage import build_sysimage
 
 
 @pytest.mark.julia

--- a/src/julia/tests/test_utils.py
+++ b/src/julia/tests/test_utils.py
@@ -17,10 +17,7 @@ except ImportError:
 
 def dummy_juliainfo():
     somepath = os.devnull  # some random path
-    return SimpleNamespace(
-        python=somepath,
-        libpython_path=somepath,
-    )
+    return SimpleNamespace(python=somepath, libpython_path=somepath)
 
 
 def test_raise_separate_cache_error_statically_linked():
@@ -28,8 +25,8 @@ def test_raise_separate_cache_error_statically_linked():
     jlinfo = dummy_juliainfo()
     with pytest.raises(RuntimeError) as excinfo:
         raise_separate_cache_error(
-            runtime, jlinfo,
-            _determine_if_statically_linked=lambda: True)
+            runtime, jlinfo, _determine_if_statically_linked=lambda: True
+        )
     assert "is statically linked" in str(excinfo.value)
 
 
@@ -38,8 +35,8 @@ def test_raise_separate_cache_error_dynamically_linked():
     jlinfo = dummy_juliainfo()
     with pytest.raises(RuntimeError) as excinfo:
         raise_separate_cache_error(
-            runtime, jlinfo,
-            _determine_if_statically_linked=lambda: False)
+            runtime, jlinfo, _determine_if_statically_linked=lambda: False
+        )
     assert "have to match exactly" in str(excinfo.value)
 
 
@@ -61,6 +58,6 @@ def test_atexit():
         @jl_atexit
         def _():
             print("atexit called")
-        ''',
+        '''
     )
     assert "atexit called" in proc.stdout

--- a/src/julia/tests/test_utils.py
+++ b/src/julia/tests/test_utils.py
@@ -6,8 +6,9 @@ import os
 
 import pytest
 
-from .test_compatible_exe import runcode
 from julia.core import raise_separate_cache_error
+
+from .test_compatible_exe import runcode
 
 try:
     from types import SimpleNamespace

--- a/src/julia/with_rebuilt.py
+++ b/src/julia/with_rebuilt.py
@@ -5,7 +5,7 @@
 variable `PYJULIA_TEST_REBUILD` is set to ``yes``.
 """
 
-from __future__ import print_function, absolute_import
+from __future__ import absolute_import, print_function
 
 import os
 import signal

--- a/src/julia/with_rebuilt.py
+++ b/src/julia/with_rebuilt.py
@@ -16,6 +16,8 @@ from contextlib import contextmanager
 from .core import JuliaInfo
 from .tools import install
 
+# fmt: off
+
 
 @contextmanager
 def maybe_rebuild(rebuild, julia):

--- a/tox.ini
+++ b/tox.ini
@@ -57,3 +57,9 @@ deps =
 commands =
     sphinx-build -b "html" -d build/doctrees {posargs} source "build/html"
 changedir = {toxinidir}/docs
+
+[testenv:style]
+deps =
+    black == 19.3b0
+commands =
+    black . {posargs:--check --diff}

--- a/tox.ini
+++ b/tox.ini
@@ -60,6 +60,8 @@ changedir = {toxinidir}/docs
 
 [testenv:style]
 deps =
+    isort == 4.3.17
     black == 19.3b0
 commands =
+    isort --recursive --check-only .
     black . {posargs:--check --diff}


### PR DESCRIPTION
The idea is to use [`black` code formatter](https://github.com/ambv/black) for the newly added code.  We can add some `fmt: off` to maintain clean `git blame`.

I'll leave it open for a while in case there are any opposing opinions.  Also maybe it's a better idea to wait until the stable release of `black`.