### PR TITLE
Do not swallow exceptions in %julia magic

### DIFF
--- a/src/julia/magic.py
+++ b/src/julia/magic.py
@@ -26,7 +26,7 @@ from IPython.core.magic import Magics, magics_class, line_cell_magic
 from IPython.utils import py3compat as compat
 from traitlets import Bool, Enum
 
-from .core import Julia, JuliaError
+from .core import Julia
 from .tools import redirect_output_streams
 
 #-----------------------------------------------------------------------------
@@ -96,14 +96,7 @@ class JuliaMagics(Magics):
         Python namespace.
         """
         src = compat.unicode_type(line if cell is None else cell)
-
-        try:
-            ans = self._julia.eval(src)
-        except JuliaError as e:
-            print(e, file=sys.stderr)
-            ans = None
-
-        return ans
+        return self._julia.eval(src)
 
 
 # Add to the global docstring the class information.

--- a/test/test_magic.py
+++ b/test/test_magic.py
@@ -23,13 +23,13 @@ def test_success_cell(julia_magics):
 
 
 def test_failure_line(julia_magics):
-    ans = julia_magics.julia('pop!([])')
-    assert ans is None
+    with pytest.raises(Exception):
+        julia_magics.julia("pop!([])")
 
 
 def test_failure_cell(julia_magics):
-    ans = julia_magics.julia(None, '1 += 1')
-    assert ans is None
+    with pytest.raises(Exception):
+        julia_magics.julia(None, "1 += 1")
 
 
 def test_revise_error():


### PR DESCRIPTION
Errors should never pass silently.
Unless explicitly silenced.

(see #266 for full context)