### PR TITLE
Fix test_juliainfo_without_pycall with Julia 1.2

### DIFF
--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -350,7 +350,8 @@ println(VERSION.patch)
 if VERSION < v"0.7.0"
     PyCall_depsfile = Pkg.dir("PyCall","deps","deps.jl")
 else
-    modpath = Base.locate_package(Base.identify_package("PyCall"))
+    pkg = Base.PkgId(Base.UUID(0x438e738f_606a_5dbb_bf0a_cddfbfd45ab0), "PyCall")
+    modpath = Base.locate_package(pkg)
     if modpath == nothing
         PyCall_depsfile = nothing
     else

--- a/src/julia/install.jl
+++ b/src/julia/install.jl
@@ -131,8 +131,6 @@ else
     end
 end
 
-# Calling `Base.locate_package` again in case PyCall is just added by
-# `Pkg.add("PyCall")`
 if VERSION < v"0.7.0"
 pkgdir = Pkg.dir("PyCall")
 else


### PR DESCRIPTION
https://github.com/JuliaLang/julia/pull/29807 removed `locate_package(::Nothing)` so the old code stopped working.  But hard-coding Pkg UUID is the right way to do it anyway.