### PR TITLE
xfail: Test #280 Do not use os.execvp in Windows

### DIFF
--- a/src/julia/python_jl.py
+++ b/src/julia/python_jl.py
@@ -23,10 +23,10 @@ by::
 
 from __future__ import print_function, absolute_import
 
-import os
 import sys
 
 from .pseudo_python_cli import make_parser, parse_args_with, ARGUMENT_HELP
+from .utils import execprog
 
 PYJL_ARGUMENT_HELP = ARGUMENT_HELP + """
   --julia JULIA  Julia runtime to be used. (default: julia)
@@ -114,7 +114,7 @@ def main(args=None):
         args = sys.argv[1:]
     ns, unused_args = parse_pyjl_args(args)
     julia = ns.julia
-    os.execvp(julia, [julia, "-e", script_jl, "--"] + unused_args)
+    execprog([julia, "-e", script_jl, "--"] + unused_args)
 
 
 if __name__ == "__main__":

--- a/src/julia/runtests.py
+++ b/src/julia/runtests.py
@@ -6,7 +6,8 @@ from __future__ import print_function, absolute_import
 
 import argparse
 import sys
-import os
+
+from .utils import execprog
 
 try:
     from shlex import quote
@@ -86,7 +87,7 @@ def runtests(pytest_args, dry_run):
     if dry_run:
         print(*map(quote, cmd))
         return
-    os.execvp(cmd[0], cmd)
+    execprog(cmd)
 
 
 class CustomFormatter(

--- a/src/julia/tests/test_runtests.py
+++ b/src/julia/tests/test_runtests.py
@@ -1,0 +1,35 @@
+import subprocess
+import sys
+from textwrap import dedent
+
+from julia.core import _enviorn
+
+from .test_compatible_exe import run
+
+
+def test_runtests_failure(tmp_path):
+    testfile = tmp_path / "test.py"
+    testcode = u"""
+    def test_THIS_TEST_MUST_FAIL():
+        assert False
+    """
+    testfile.write_text(dedent(testcode))
+
+    proc = run(
+        [
+            sys.executable,
+            "-m",
+            "julia.runtests",
+            "--",
+            str(testfile),
+            "--no-julia",
+            "-k",
+            "test_THIS_TEST_MUST_FAIL",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        universal_newlines=True,
+        env=_enviorn,
+    )
+    assert proc.returncode == 1
+    assert "1 failed" in proc.stdout

--- a/src/julia/tests/test_runtests.py
+++ b/src/julia/tests/test_runtests.py
@@ -7,6 +7,10 @@ from julia.core import _enviorn
 from .test_compatible_exe import run
 
 
+def test_THIS_TEST_MUST_FAIL():
+    assert False
+
+
 def test_runtests_failure(tmp_path):
     testfile = tmp_path / "test.py"
     testcode = u"""

--- a/src/julia/utils.py
+++ b/src/julia/utils.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, print_function
+
+import os
+import subprocess
+import sys
+
+is_linux = sys.platform.startswith("linux")
+is_windows = os.name == "nt"
+is_apple = sys.platform == "darwin"
+
+
+def _execprog_os(cmd):
+    os.execvp(cmd[0], cmd)
+
+
+def _execprog_subprocess(cmd):
+    sys.exit(subprocess.call(cmd))
+
+
+if is_windows:
+    # https://bugs.python.org/issue19124
+    execprog = _execprog_subprocess
+else:
+    execprog = _execprog_os


### PR DESCRIPTION
Test that julia.runtests can cause CI failure #280