### PR TITLE
Remove obsolete warning: python-jl works on Windows now [ci skip]

### DIFF
--- a/src/julia/python_jl.py
+++ b/src/julia/python_jl.py
@@ -7,8 +7,6 @@ process.  This avoids the known problem with pre-compilation cache in
 Debian-based distribution such as Ubuntu and Python executable installed by
 Conda in Linux.
 
-.. WARNING:: This CLI does not work on Windows.
-
 Although this script has -i option and it can do a basic REPL, contrl-c may
 crash the whole process.  Consider using IPython >= 7 which can be launched
 by::


### PR DESCRIPTION
https://github.com/JuliaPy/pyjulia/pull/289 fixed the issue so this warning is inaccurate now.