### PR TITLE
Automatically deploy package to test.pypi.org

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,11 +41,48 @@ matrix:
           - JULIA_VERSION=0.6.4
           - CROSS_VERSION=1
         os: osx
+
+      # Upload the package to `test.pypi.org` when there is a push to
+      # `release/test` branch:
+      - stage: "Test deploy"
+        python: "3.6"
+        env: []
+        deploy:
+          provider: pypi
+          server: https://test.pypi.org/legacy/
+          user: tkf
+          password:
+            secure: dHo58o6r/V2QvsCOoPwGxwn8gEKfeUXFpYCtYXmqH/MPFOqEq2sXHQJ0v4CsFciwYqLnFNsNBpn0k6gvzmFkmulux4ELs33+noTgPRXNLNYmQqW1WqYHKGxv76c/olN4X17vvFafsNXB50MzdZuH5zMO9NcG36c86/UlT42L+ek=
+          distributions: "sdist bdist_wheel"
+          on:
+            branch: release/test
+            repo: JuliaPy/pyjulia
+        if: branch = release/test
+        script: skip
+        after_success: skip
+
+      # Test the package uploaded to `test.pypi.org`:
+      - stage: "Test upload"
+        if: branch = release/test OR branch = upload/test
+        python: "3.6"
+        env:
+          - JULIA_VERSION=1.0
+        before_script:
+          - ./ci/install-julia.sh "$JULIA_VERSION"
+          - pip install --quiet tox
+        script:
+          - cd ci/test-upload && tox
+        after_script:
+          - cat ci/test-upload/.tox/py/log/pytest.log
+        after_success: skip
+
   allow_failures:
     - env: JULIA_VERSION=nightly
 branches:
   only:
     - master
+    - release/test
+    - upload/test
 notifications:
   email: false
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,7 +71,7 @@ matrix:
           - ./ci/install-julia.sh "$JULIA_VERSION"
           - pip install --quiet tox
         script:
-          - cd ci/test-upload && tox
+          - (cd ci/test-upload && tox)
         after_script:
           - cat ci/test-upload/.tox/py/log/pytest.log
         after_success: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -58,6 +58,7 @@ matrix:
             branch: release/test
             repo: JuliaPy/pyjulia
         if: branch = release/test
+        before_script: skip
         script: skip
         after_success: skip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,11 @@ matrix:
         if: branch = release/test
         before_script: skip
         script: skip
-        after_success: skip
+        after_success:
+          - echo "skipped"
+          # Do not use `after_success: skip` as it would skip the deploy
+          # step.
+          # https://github.com/travis-ci/travis-ci/issues/8337#issuecomment-326838809
 
       # Test the package uploaded to `test.pypi.org`:
       - stage: "Test upload"

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,8 @@ upload: dist
 	# upload to Python package index`
 	twine upload dist/*
 
+release:
+	rm -rf dist
+	pip download --dest dist --no-deps --index-url https://test.pypi.org/simple/ julia
+	pip download --dest dist --no-deps --index-url https://test.pypi.org/simple/ julia --no-binary :all:
+	twine upload dist/julia-*-any.whl dist/julia-*.tar.gz

--- a/ci/test-upload/tox.ini
+++ b/ci/test-upload/tox.ini
@@ -5,6 +5,7 @@ indexserver =
 skipsdist = True
 
 [testenv]
+pip_pre = true
 deps =
     :test:julia
 

--- a/ci/test-upload/tox.ini
+++ b/ci/test-upload/tox.ini
@@ -4,6 +4,8 @@ skipsdist = True
 
 [testenv]
 deps =
+    shell-retry == 0.0.8
+
     # These are the packages listed in extras_require in setup.py.
     # Not using `julia[test]` to avoid installing the test
     # dependencies from `test.pypi.org`:
@@ -13,6 +15,7 @@ deps =
     mock
 
 commands =
+    shell-retry --backoff=2 --interval-max=20 --retry-count=30 --verbose -- \
     pip install --index-url https://test.pypi.org/simple/ julia==0.4.1.dev
 
     python -c "from julia import install; install()"

--- a/ci/test-upload/tox.ini
+++ b/ci/test-upload/tox.ini
@@ -1,14 +1,9 @@
 [tox]
 envlist = py
-indexserver =
-    test = https://test.pypi.org/simple/
 skipsdist = True
 
 [testenv]
-pip_pre = true
 deps =
-    :test:julia
-
     # These are the packages listed in extras_require in setup.py.
     # Not using `julia[test]` to avoid installing the test
     # dependencies from `test.pypi.org`:
@@ -18,6 +13,8 @@ deps =
     mock
 
 commands =
+    pip install --index-url https://test.pypi.org/simple/ julia==0.4.1.dev
+
     python -c "from julia import install; install()"
     python -m julia.runtests -- \
         --log-file {envlogdir}/pytest.log \

--- a/ci/test-upload/tox.ini
+++ b/ci/test-upload/tox.ini
@@ -1,0 +1,26 @@
+[tox]
+envlist = py
+indexserver =
+    test = https://test.pypi.org/simple/
+skipsdist = True
+
+[testenv]
+deps =
+    :test:julia
+
+    # These are the packages listed in extras_require in setup.py.
+    # Not using `julia[test]` to avoid installing the test
+    # dependencies from `test.pypi.org`:
+    numpy
+    ipython
+    pytest >= 4.4
+    mock
+
+commands =
+    python -c "from julia import install; install()"
+    python -m julia.runtests -- \
+        --log-file {envlogdir}/pytest.log \
+	{posargs}
+
+[pytest]
+log_file_level = DEBUG

--- a/docs/source/development.rst
+++ b/docs/source/development.rst
@@ -1,0 +1,47 @@
+Development
+===========
+
+Release
+-------
+
+Step 1: Test the release candidate using ``test.pypi.org``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Bump the version number and push the change to ``release/test`` branch
+in https://github.com/JuliaPy/pyjulia.  This triggers a CI that:
+
+1. runs the tests,
+2. releases the package on ``test.pypi.org``,
+3. installs the released package, and
+4. then runs the test with the installed package.
+
+
+Step 2: Release
+^^^^^^^^^^^^^^^
+
+If the CI pass, run:
+
+.. code-block:: console
+
+   $ make release
+
+
+Step 3: Tag
+^^^^^^^^^^^
+
+Create a Git tag with the form ``vX.Y.Z``, merge ``release/test`` to
+``master`` branch, and then push the tag and ``master`` branch.
+
+
+Special branches
+----------------
+
+``release/test``
+    Push to this branch triggers the deploy to ``test.pypi.org`` if all
+    the tests are passed.  Uploaded package is tested in the next
+    stage.
+
+``upload/test``
+    Push to this branch triggers the test that would be run for the
+    final stage for ``release/test``.  Handy for just testing this
+    stage.

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -22,6 +22,7 @@ PyJulia is tested against Python versions 2.7, 3.5, 3.6, and 3.7.
    how_it_works
    limitations
    testing
+   development
 
 Indices and tables
 ==================

--- a/setup.py
+++ b/setup.py
@@ -73,6 +73,7 @@ setup(name='julia',
       package_dir={"": "src"},
       package_data={'julia': ['fake-julia/*', "*.jl"]},
       extras_require={
+          # Update `ci/test-upload/tox.ini` when "test" is changed:
           "test": [
               "numpy",
               "ipython",


### PR DESCRIPTION
This patch adds two stages to release the package at test.pypi.org and then test the deployed package.  These two stages are triggered when there is a push to the special branch `release/test`.  The package uploaded to test.pypi.org can then be released on the standard pypi.org server by locally running `pip download` and `twine` (via `make release`).