### PR TITLE
Added user site bin for julia-py

### DIFF
--- a/src/julia/juliainfo.jl
+++ b/src/julia/juliainfo.jl
@@ -9,7 +9,7 @@ using Libdl
 using Pkg
 
 println(Base.Sys.BINDIR)
-println(Libdl.dlpath(string("lib", splitext(Base.julia_exename())[1])))
+println(Libdl.dlpath("libjulia"))
 println(unsafe_string(Base.JLOptions().image_file))
 
 pkg = Base.PkgId(Base.UUID(0x438e738f_606a_5dbb_bf0a_cddfbfd45ab0), "PyCall")

--- a/src/julia/tools.py
+++ b/src/julia/tools.py
@@ -2,9 +2,11 @@ from __future__ import absolute_import, print_function
 
 import glob
 import os
+import platform
 import re
 import site
 import subprocess
+import sysconfig
 import sys
 
 from .core import JuliaNotFound, which
@@ -140,30 +142,44 @@ def julia_py_executable(executable=sys.executable):
     """
     Path to ``julia-py`` executable installed for this Python executable.
     """
-    basedirs = {os.path.dirname(executable),
-                os.path.join(site.USER_BASE, "bin")}
-    stempaths = {os.path.join(basedir, "julia-py") for basedir in basedirs}
-    candidates = {os.path.basename(p): p for stempath in stempaths
-                                         for p in glob.glob(stempath + "*")}
-    if not candidates:
-        raise RuntimeError(
-            "``julia-py`` executable is not found for Python installed at {}".format(
-                executable
-            )
-        )
+    basenames = []
+    basedirs = []
+    platform_sys = platform.system()
 
-    for basename in ["julia-py", "julia-py.exe", "julia-py.cmd"]:
-        try:
-            return candidates[basename]
-        except KeyError:
+    if platform_sys in {"Linux", "Darwin"}:
+        basenames = ["julia-py"]
+        basedirs = [
+            basedirs.append(os.path.join(site.USER_BASE, "bin")),
+            os.path.join(site.PREFIXES[0], "bin"),
+            os.path.dirname(executable)
+          ]
+    elif platform_sys == "win32":
+        basenames = ["julia-py.exe", "julia-py.cmd"]
+        basedirs = [
+            os.path.join(site.USER_BASE,
+                         "Python" + sysconfig.get_config_vars("VERSION"),
+                         "Scripts"),
+            os.path.join(site.PREFIXES[0], "Scripts"),
+            os.path.dirname(executable)
+          ]
+    else:
+        raise RuntimeError("Unsupported platform: {}".format(platform_sys))
+
+    for basedir in basedirs:
+        stempath = os.path.join(basedir, "julia-py")
+        candidates = {os.path.basename(p): p for p in glob.glob(stempath + "*")}
+        if not candidates:
             continue
+        for basename in basenames:
+            try:
+                return candidates[basename]
+            except KeyError:
+                continue
 
     raise RuntimeError(
-        """\
-``julia-py`` with following unrecognized extension(s) are found.
-Please report it at https://github.com/JuliaPy/pyjulia/issues
-with the full traceback.
-Files found:
-    """
-        + "    \n".join(sorted(candidates))
-    )
+                    """\``julia-py`` executable not found in {} looking for
+                    {}. If the file exists with another extension, please report it
+                    at https://github.com/JuliaPy/pyjulia/issues
+                    with the full traceback.
+                    """.format(basedirs, basenames)
+                )

--- a/src/julia/tools.py
+++ b/src/julia/tools.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function
 import glob
 import os
 import re
+import site
 import subprocess
 import sys
 
@@ -139,8 +140,11 @@ def julia_py_executable(executable=sys.executable):
     """
     Path to ``julia-py`` executable installed for this Python executable.
     """
-    stempath = os.path.join(os.path.dirname(executable), "julia-py")
-    candidates = {os.path.basename(p): p for p in glob.glob(stempath + "*")}
+    basedirs = {os.path.dirname(executable),
+                os.path.join(site.USER_BASE, "bin")}
+    stempaths = {os.path.join(basedir, "julia-py") for basedir in basedirs}
+    candidates = {os.path.basename(p): p for stempath in stempaths
+                                         for p in glob.glob(stempath + "*")}
     if not candidates:
         raise RuntimeError(
             "``julia-py`` executable is not found for Python installed at {}".format(


### PR DESCRIPTION
Since I'm using `setup.py develop --user` in my setup, `julia-py` binary is installed in `~/.local/bin`. Rather than hardcoding the path to be at the same place as the `python` binary, one should look also there. This patch adds this behavior. Do you think one could also use `site.PREFIXES` to replace the default binary path? In that case I will create another patch.