### PR TITLE
Make CI on AppVeyor work with latest tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -96,6 +96,7 @@ before_script:
   # Following which command will catch installation failure:
   - PYTHON=${PYTHON:-python}
   - which $PYTHON
+  - $PYTHON -m pip install --quiet --upgrade pip
   - $PYTHON -m pip --version
   - $PYTHON -m pip install --quiet tox coveralls
   - $PYTHON ci/install_pycall.py

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ build_script:
   - "SET PYTHON=%PYTHONDIR%\\python.exe"
   - "%PYTHONDIR%\\python.exe -m pip install --quiet --upgrade pip virtualenv setuptools"
   - "%PYTHONDIR%\\python.exe -m pip --version"
-  - "%PYTHONDIR%\\python.exe -m pip install --quiet tox==3.9.0"
+  - "%PYTHONDIR%\\python.exe -m pip install --quiet tox==3.10.0"
   - "python2.7 -m pip install --quiet --upgrade pip virtualenv setuptools"
   - "python2.7 -m pip --version"
   - "%PYTHONDIR%\\python.exe ci\\install_pycall.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,11 +56,14 @@ install:
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia
 
 build_script:
-  - "SET PATH=%PYTHONDIR%;%PYTHONDIR%\\Scripts;C:\\projects\\julia\\bin;%PATH%"
+  - "SET PATH=%cd%\\%BATDIR%;%PYTHONDIR%;%PYTHONDIR%\\Scripts;C:\\projects\\julia\\bin;%PATH%"
   - "\"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\editbin.exe\" %PYTHONDIR%\\python.exe /STACK:8000000"
   - "SET PYTHON=%PYTHONDIR%\\python.exe"
   - "%PYTHONDIR%\\python.exe -m pip install --quiet --upgrade pip"
+  - "%PYTHONDIR%\\python.exe -m pip --version"
   - "%PYTHONDIR%\\python.exe -m pip install --quiet tox"
+  - "python2.7 -m pip install --quiet --upgrade pip"
+  - "python2.7 -m pip --version"
   - "%PYTHONDIR%\\python.exe ci\\install_pycall.py"
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,9 @@ environment:
   #   BATDIR: ci\appveyor\win32
 
   # 64 julia-1.0 Python-35
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
-    PYTHONDIR: "C:\\Python35-x64"
-    BATDIR: ci\appveyor\win64
+  # - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/1.0/julia-1.0-latest-win64.exe"
+  #   PYTHONDIR: "C:\\Python35-x64"
+  #   BATDIR: ci\appveyor\win64
 
   # 64 julia latest Python-35
   # - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
@@ -73,7 +73,7 @@ test_script:
   # Rebuild PyCall.ji for each Python interpreter before testing:
   - "SET PYJULIA_TEST_REBUILD=yes"
   - tox --version
-  - tox
+  - tox -rvv -e py27
 
 on_finish:
   - ps: cat .tox\py\log\pytest.log

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,10 @@ build_script:
   - "SET PATH=%cd%\\%BATDIR%;%PYTHONDIR%;%PYTHONDIR%\\Scripts;C:\\projects\\julia\\bin;%PATH%"
   - "\"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\editbin.exe\" %PYTHONDIR%\\python.exe /STACK:8000000"
   - "SET PYTHON=%PYTHONDIR%\\python.exe"
-  - "%PYTHONDIR%\\python.exe -m pip install --quiet --upgrade pip virtualenv"
+  - "%PYTHONDIR%\\python.exe -m pip install --quiet --upgrade pip virtualenv setuptools"
   - "%PYTHONDIR%\\python.exe -m pip --version"
   - "%PYTHONDIR%\\python.exe -m pip install --quiet tox"
-  - "python2.7 -m pip install --quiet --upgrade pip virtualenv"
+  - "python2.7 -m pip install --quiet --upgrade pip virtualenv setuptools"
   - "python2.7 -m pip --version"
   - "%PYTHONDIR%\\python.exe ci\\install_pycall.py"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,8 @@ build_script:
   - "SET PATH=%PYTHONDIR%;%PYTHONDIR%\\Scripts;C:\\projects\\julia\\bin;%PATH%"
   - "\"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\editbin.exe\" %PYTHONDIR%\\python.exe /STACK:8000000"
   - "SET PYTHON=%PYTHONDIR%\\python.exe"
-  - "%PYTHONDIR%\\python.exe -m pip install --quiet tox==3.9.0"
+  - "%PYTHONDIR%\\python.exe -m pip install --quiet --upgrade pip"
+  - "%PYTHONDIR%\\python.exe -m pip install --quiet tox"
   - "%PYTHONDIR%\\python.exe ci\\install_pycall.py"
 
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -61,7 +61,7 @@ build_script:
   - "SET PYTHON=%PYTHONDIR%\\python.exe"
   - "%PYTHONDIR%\\python.exe -m pip install --quiet --upgrade pip virtualenv setuptools"
   - "%PYTHONDIR%\\python.exe -m pip --version"
-  - "%PYTHONDIR%\\python.exe -m pip install --quiet tox"
+  - "%PYTHONDIR%\\python.exe -m pip install --quiet tox==3.9.0"
   - "python2.7 -m pip install --quiet --upgrade pip virtualenv setuptools"
   - "python2.7 -m pip --version"
   - "%PYTHONDIR%\\python.exe ci\\install_pycall.py"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,10 @@ build_script:
   - "SET PATH=%cd%\\%BATDIR%;%PYTHONDIR%;%PYTHONDIR%\\Scripts;C:\\projects\\julia\\bin;%PATH%"
   - "\"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\editbin.exe\" %PYTHONDIR%\\python.exe /STACK:8000000"
   - "SET PYTHON=%PYTHONDIR%\\python.exe"
-  - "%PYTHONDIR%\\python.exe -m pip install --quiet --upgrade pip"
+  - "%PYTHONDIR%\\python.exe -m pip install --quiet --upgrade pip virtualenv"
   - "%PYTHONDIR%\\python.exe -m pip --version"
   - "%PYTHONDIR%\\python.exe -m pip install --quiet tox"
-  - "python2.7 -m pip install --quiet --upgrade pip"
+  - "python2.7 -m pip install --quiet --upgrade pip virtualenv"
   - "python2.7 -m pip --version"
   - "%PYTHONDIR%\\python.exe ci\\install_pycall.py"
 

--- a/ci/appveyor/win32/python2.7.bat
+++ b/ci/appveyor/win32/python2.7.bat
@@ -1,1 +1,2 @@
+@echo off
 @C:\Python27\python.exe %*

--- a/ci/appveyor/win32/python3.5.bat
+++ b/ci/appveyor/win32/python3.5.bat
@@ -1,1 +1,2 @@
+@echo off
 @C:\Python35\python.exe %*

--- a/ci/appveyor/win64/python2.7.bat
+++ b/ci/appveyor/win64/python2.7.bat
@@ -1,1 +1,2 @@
+@echo off
 @C:\Python27-x64\python.exe %*

--- a/ci/appveyor/win64/python3.5.bat
+++ b/ci/appveyor/win64/python3.5.bat
@@ -1,1 +1,2 @@
+@echo off
 @C:\Python35-x64\python.exe %*

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,8 @@ deps =
 extras =
     test
 commands =
+    python -c 'import sys; print(sys.maxsize)'
+
     python -m julia.find_libpython --list-all --verbose
     # Print libpython candidates found by `find_libpython`.  It may be
     # useful for debugging.


### PR DESCRIPTION
Trying to fix recent failures on Windows; e.g., https://ci.appveyor.com/project/Keno/pyjulia/builds/26336104

See also: https://github.com/tox-dev/tox/issues/791#issuecomment-492002896
