### PR TITLE
Use tox 3.9.0 in AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,7 +59,7 @@ build_script:
   - "SET PATH=%PYTHONDIR%;%PYTHONDIR%\\Scripts;C:\\projects\\julia\\bin;%PATH%"
   - "\"C:\\Program Files (x86)\\Microsoft Visual Studio 14.0\\VC\\bin\\amd64\\editbin.exe\" %PYTHONDIR%\\python.exe /STACK:8000000"
   - "SET PYTHON=%PYTHONDIR%\\python.exe"
-  - "%PYTHONDIR%\\python.exe -m pip install --quiet tox"
+  - "%PYTHONDIR%\\python.exe -m pip install --quiet tox==3.9.0"
   - "%PYTHONDIR%\\python.exe ci\\install_pycall.py"
 
 test_script:
@@ -68,6 +68,7 @@ test_script:
 
   # Rebuild PyCall.ji for each Python interpreter before testing:
   - "SET PYJULIA_TEST_REBUILD=yes"
+  - tox --version
   - tox
 
 on_finish:


### PR DESCRIPTION
It looks like `bat` file-based setup stopped working as of tox 3.10.0 (see #313).  Let's use tox 3.9.0 for now.