### PR TITLE
Fix install.jl for newer Julia

### DIFF
--- a/src/julia/install.jl
+++ b/src/julia/install.jl
@@ -6,35 +6,18 @@ code_no_precompile_needed = 113
 
 
 if VERSION < v"0.7.0"
-macro info(x)
-    :(info($(esc(x))))
+    error("Unsupported Julia version $VERSION")
 end
-macro warn(x)
-    :(warn($(esc(x))))
-end
-stderr = STDERR
-else
-using Pkg
-end  # if
 
+using Pkg
+using InteractiveUtils
 
 @info "Julia version info"
-if VERSION >= v"0.7.0-DEV.3630"
-using InteractiveUtils
 versioninfo(verbose=true)
-else
-versioninfo(true)
-end  # if
 
 @info "Julia executable: $(Base.julia_cmd().exec[1])"
 
-
-if VERSION < v"0.7.0"
-pycall_is_installed = Pkg.installed("PyCall") !== nothing
-else
 pycall_is_installed = haskey(Pkg.installed(), "PyCall")
-end  # if
-
 
 @info "Trying to import PyCall..."
 
@@ -45,21 +28,9 @@ end
 
 try
     # `import PyCall` cannot be caught?
-    if VERSION < v"0.7.0"
-    Base.require(:PyCall)
-    @assert PyCall.python isa String
-    else
     global PyCall = Base.require(Main, :PyCall)
-    end  # if
 catch err
-    @static if VERSION < v"0.7.0"
-    @warn """
-    `import PyCall` failed with:
-    $err
-    """
-    else
     @error "`import PyCall` failed" exception=(err, catch_backtrace())
-    end  # if
     global PyCall = DummyPyCall
 end
 
@@ -131,13 +102,9 @@ else
     end
 end
 
-if VERSION < v"0.7.0"
-pkgdir = Pkg.dir("PyCall")
-else
 pkg = Base.PkgId(Base.UUID(0x438e738f_606a_5dbb_bf0a_cddfbfd45ab0), "PyCall")
 modpath = Base.locate_package(pkg)
 pkgdir = joinpath(dirname(modpath), "..")
-end  # if
 
 if print_logfile
     logfile = joinpath(pkgdir, "deps", "build.log")

--- a/src/julia/install.jl
+++ b/src/julia/install.jl
@@ -17,7 +17,8 @@ versioninfo(verbose=true)
 
 @info "Julia executable: $(Base.julia_cmd().exec[1])"
 
-pycall_is_installed = haskey(Pkg.installed(), "PyCall")
+pkgid = Base.PkgId(Base.UUID(0x438e738f_606a_5dbb_bf0a_cddfbfd45ab0), "PyCall")
+pycall_is_installed = Base.locate_package(pkgid) !== nothing
 
 @info "Trying to import PyCall..."
 
@@ -102,8 +103,7 @@ else
     end
 end
 
-pkg = Base.PkgId(Base.UUID(0x438e738f_606a_5dbb_bf0a_cddfbfd45ab0), "PyCall")
-modpath = Base.locate_package(pkg)
+modpath = Base.locate_package(pkgid)
 pkgdir = joinpath(dirname(modpath), "..")
 
 if print_logfile


### PR DESCRIPTION
Trying to fix:

```
[ Info: Julia executable: /home/travis/build/JuliaPy/pyjulia/julia-1a6549a870/bin/julia
ERROR: LoadError: UndefVarError: installed not defined
Stacktrace:
 [1] getproperty(::Module, ::Symbol) at ./Base.jl:26
 [2] top-level scope at /home/travis/build/JuliaPy/pyjulia/src/julia/install.jl:35
 [3] include(::Module, ::String) at ./Base.jl:377
 [4] exec_options(::Base.JLOptions) at ./client.jl:296
 [5] _start() at ./client.jl:492
in expression starting at /home/travis/build/JuliaPy/pyjulia/src/julia/install.jl:32
```

https://travis-ci.org/JuliaPy/pyjulia/jobs/603126698#L235-L243 which came up in https://github.com/JuliaPy/pyjulia/pull/331