### PR TITLE
Fix test/CI failures due to upstream changes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -91,7 +91,15 @@ notifications:
 before_script:
   - echo ./ci/install-julia.sh "$JULIA_VERSION"
   - ./ci/install-julia.sh "$JULIA_VERSION"
-  - if [ "$TRAVIS_OS_NAME" = "osx" -a "$PYTHON" = "python3" ]; then brew update; brew upgrade python || echo "Ignoring errors..."; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" -a "$PYTHON" = "python3" ];
+    then
+        brew update;
+        brew upgrade python || echo "Ignoring errors...";
+        if ! which $PYTHON;
+        then
+            PYTHON="$(ls -1 /usr/local/opt/python@3.*/bin/python3 | head -n1)";
+        fi;
+    fi
   - if [ "$TRAVIS_OS_NAME" = "osx" -a "$PYTHON" = "python2" ]; then brew update; brew list python@2 &>/dev/null || brew install python@2 || echo "Ignoring errors..."; fi
   # Ignoring errors from brew since it may actually be OK to do so.
   # Following which command will catch installation failure:

--- a/src/julia/magic.py
+++ b/src/julia/magic.py
@@ -23,11 +23,15 @@ import sys
 import warnings
 
 from IPython.core.magic import Magics, line_cell_magic, magics_class
-from IPython.utils import py3compat as compat
 from traitlets import Bool, Enum
 
 from .core import Julia, JuliaError
 from .tools import redirect_output_streams
+
+try:
+    unicode
+except NameError:
+    unicode = str
 
 try:
     from IPython.core.magic import no_var_expand
@@ -103,7 +107,7 @@ class JuliaMagics(Magics):
         Execute code in Julia, and pull some of the results back into the
         Python namespace.
         """
-        src = compat.unicode_type(line if cell is None else cell)
+        src = unicode(line if cell is None else cell)
 
         # We assume the caller's frame is the first parent frame not in the
         # IPython module. This seems to work with IPython back to ~v5, and

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,6 @@ deps =
     ipython==7.10.1
     ipython-genutils==0.2.0
     jedi==0.15.1
-    julia==0.5.1.dev0
     mock==3.0.5
     more-itertools==8.0.2
     numpy==1.17.4

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist = py3
 [testenv]
 deps =
     pytest-cov
+    coverage < 5
 extras =
     test
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -3,33 +3,7 @@ envlist = py3
 
 [testenv]
 deps =
-    attrs==19.3.0
-    backcall==0.1.0
-    coverage==4.5.4
-    decorator==4.4.1
-    importlib-metadata==1.3.0
-    ipython==7.10.1
-    ipython-genutils==0.2.0
-    jedi==0.15.1
-    mock==3.0.5
-    more-itertools==8.0.2
-    numpy==1.17.4
-    packaging==19.2
-    parso==0.5.1
-    pexpect==4.7.0
-    pickleshare==0.7.5
-    pluggy==0.13.1
-    prompt-toolkit==3.0.2
-    ptyprocess==0.6.0
-    py==1.8.0
-    Pygments==2.5.2
-    pyparsing==2.4.5
-    pytest==5.3.1
-    pytest-cov==2.8.1
-    six==1.13.0
-    traitlets==4.3.3
-    wcwidth==0.1.7
-    zipp==0.6.0
+    pytest-cov
 extras =
     test
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,34 @@ envlist = py3
 
 [testenv]
 deps =
-    pytest-cov
+    attrs==19.3.0
+    backcall==0.1.0
+    coverage==4.5.4
+    decorator==4.4.1
+    importlib-metadata==1.3.0
+    ipython==7.10.1
+    ipython-genutils==0.2.0
+    jedi==0.15.1
+    julia==0.5.1.dev0
+    mock==3.0.5
+    more-itertools==8.0.2
+    numpy==1.17.4
+    packaging==19.2
+    parso==0.5.1
+    pexpect==4.7.0
+    pickleshare==0.7.5
+    pluggy==0.13.1
+    prompt-toolkit==3.0.2
+    ptyprocess==0.6.0
+    py==1.8.0
+    Pygments==2.5.2
+    pyparsing==2.4.5
+    pytest==5.3.1
+    pytest-cov==2.8.1
+    six==1.13.0
+    traitlets==4.3.3
+    wcwidth==0.1.7
+    zipp==0.6.0
 extras =
     test
 commands =


### PR DESCRIPTION
* Don't use IPython.utils.py3compat
* Don't use coverage 5.x (see: https://github.com/nedbat/coveragepy/issues/881)
* Fix python3 installation for macOS