### PR TITLE
Register pytest markers to avoid warnings

### DIFF
--- a/src/julia/pytestplugin.py
+++ b/src/julia/pytestplugin.py
@@ -107,6 +107,14 @@ Try:
 # https://docs.pytest.org/en/latest/reference.html#_pytest.hookspec.pytest_sessionstart
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "julia: mark tests to be skipped with --no-julia."
+    )
+    # https://docs.pytest.org/en/latest/writing_plugins.html#registering-markers
+    # https://docs.pytest.org/en/latest/mark.html#registering-marks
+
+
 @pytest.fixture(scope="session")
 def julia(request):
     """ pytest fixture for providing a `Julia` instance. """

--- a/tox.ini
+++ b/tox.ini
@@ -46,6 +46,10 @@ log_file_level = DEBUG
 # Essential flags and configuration must be added to
 # src/julia/runtests.py
 
+markers =
+    pyjulia__using_default_setup: mark tests to be skipped with non-default setup
+# https://docs.pytest.org/en/latest/mark.html#registering-marks
+
 [coverage:paths]
 source =
     src/julia


### PR DESCRIPTION
This PR gets rid of warnings like

```
=============================== warnings summary ===============================
.tox/py/lib/python3.6/site-packages/_pytest/mark/structures.py:327
.tox/py/lib/python3.6/site-packages/_pytest/mark/structures.py:327
  /home/travis/build/JuliaPy/pyjulia/.tox/py/lib/python3.6/site-packages/_pytest/mark/structures.py:327: PytestUnknownMarkWarning: Unknown pytest.mark.pyjulia__using_default_setup - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,
.tox/py/lib/python3.6/site-packages/_pytest/mark/structures.py:327
.tox/py/lib/python3.6/site-packages/_pytest/mark/structures.py:327
.tox/py/lib/python3.6/site-packages/_pytest/mark/structures.py:327
  /home/travis/build/JuliaPy/pyjulia/.tox/py/lib/python3.6/site-packages/_pytest/mark/structures.py:327: PytestUnknownMarkWarning: Unknown pytest.mark.julia - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/latest/mark.html
    PytestUnknownMarkWarning,
-- Docs: https://docs.pytest.org/en/latest/warnings.html
```

--- https://travis-ci.org/JuliaPy/pyjulia/jobs/634617822#L452-L465

After: https://travis-ci.org/JuliaPy/pyjulia/jobs/634618814#L459
