### PR TITLE
Add --julia option for undoing --no-julia

### DIFF
--- a/docs/source/pytest.rst
+++ b/docs/source/pytest.rst
@@ -49,6 +49,10 @@ Following options can be passed to :program:`pytest`
 
    Skip tests that require julia.
 
+.. option:: --julia
+
+   Undo ``--no-julia``; i.e., run tests that require julia.
+
 .. option:: --julia-runtime
 
    Julia executable to be used.  Defaults to environment variable

--- a/src/julia/pytestplugin.py
+++ b/src/julia/pytestplugin.py
@@ -19,7 +19,15 @@ def pytest_addoption(parser):
         "--no-julia",
         action="store_false",
         dest="julia",
+        default=True,
         help="Skip tests that require julia.",
+    )
+    parser.addoption(
+        "--julia",
+        action="store_true",
+        dest="julia",
+        default=True,
+        help="Undo `--no-julia`; i.e., run tests that require julia.",
     )
     parser.addoption(
         "--julia-runtime",


### PR DESCRIPTION
It's handy to turn off PyJulia tests using

    addopts = -p julia.pytestplugin --no-julia

and then run it optionally with some flag.  This patch adds a flag
--julia for this.