### PR TITLE
Stop testing Python 2 on AppVeyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
 
-  TOXENV: py,py27
+  TOXENV: py
   TOX_TESTENV_PASSENV: DISTUTILS_USE_SDK MSSdk INCLUDE LIB
   # https://packaging.python.org/guides/supporting-windows-using-appveyor/#testing-with-tox
 
@@ -73,4 +73,3 @@ test_script:
 
 on_finish:
   - ps: cat .tox\py\log\pytest.log
-  - ps: cat .tox\py27\log\pytest.log


### PR DESCRIPTION
The current setting is not working anymore: https://ci.appveyor.com/project/Keno/pyjulia/builds/30218844 (https://github.com/JuliaPy/pyjulia/pull/351)