### PR TITLE
Run tests using GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - windows-latest
         architecture: [x64, x86]
         python-version: ['3.7', '3.8']
-        julia-version: ['1.3', '~1.5.0-rc1']
+        julia-version: ['1.0', '1.3', '~1.5.0-rc1']
         exclude:
           - os: ubuntu-latest
             architecture: x86

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - windows-latest
         architecture: [x64, x86]
         python-version: ['3.7', '3.8']
-        julia-version: ['1.0', '1.3', '~1.5.0-rc1']
+        julia-version: ['1.3', '~1.5.0-rc1']
         exclude:
           - os: ubuntu-latest
             architecture: x86

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-          # macOS does not have libpython at the moment:
-          # https://github.com/actions/virtual-environments/issues/125
-          # - macos-latest
+          - macos-latest
           - windows-latest
         architecture: [x64, x86]
         python-version: ['3.7', '3.8']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,6 +22,8 @@ jobs:
         exclude:
           - os: ubuntu-latest
             architecture: x86
+          - os: macos-latest
+            architecture: x86
       fail-fast: false
     name: ${{ matrix.os }} ${{ matrix.architecture }}
       Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Run test
         run: python -m tox
         env:
+          CI: 'true'  # run tests marked by @only_in_ci
           TOXENV: py
           PYJULIA_TEST_REBUILD: 'yes'
       - run: cat .tox/py/log/pytest.log

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,10 @@ jobs:
             architecture: x86
           - os: macos-latest
             architecture: x86
+          - os: macos-latest
+            julia-version: '1.3'
+          - os: windows-latest
+            julia-version: '1.3'
       fail-fast: false
     name: ${{ matrix.os }} ${{ matrix.architecture }}
       Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,7 @@ jobs:
           - windows-latest
         architecture: [x64, x86]
         python-version: ['3.7', '3.8']
-        julia-version: ['1.3']
+        julia-version: ['1.3', '~1.5.0-rc1']
         exclude:
           - os: ubuntu-latest
             architecture: x86

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,56 @@
+name: Main workflow
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - ubuntu-latest
+          # macOS does not have libpython at the moment:
+          # https://github.com/actions/virtual-environments/issues/125
+          # - macos-latest
+          - windows-latest
+        architecture: [x64, x86]
+        python-version: ['3.7', '3.8']
+        julia-version: ['1.3']
+        exclude:
+          - os: ubuntu-latest
+            architecture: x86
+      fail-fast: false
+    name: ${{ matrix.os }} ${{ matrix.architecture }}
+      Python ${{ matrix.python-version }}
+      Julia ${{ matrix.julia-version }}
+    steps:
+      - uses: actions/checkout@v1
+      - name: Setup python
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: ${{ matrix.architecture }}
+      - name: Setup julia
+        uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.julia-version }}
+          arch: ${{ matrix.architecture }}
+      - run: python src/julia/find_libpython.py --list-all --verbose
+      - name: Install tox
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install --upgrade tox
+      - name: Install PyCall
+        run: python ci/install_pycall.py
+      - name: Run test
+        run: python -m tox
+        env:
+          TOXENV: py
+          PYJULIA_TEST_REBUILD: 'yes'
+      - run: cat .tox/py/log/pytest.log
+        if: always()

--- a/src/julia/tests/test_python_jl.py
+++ b/src/julia/tests/test_python_jl.py
@@ -10,6 +10,8 @@ from julia.core import which
 from julia.python_jl import parse_pyjl_args
 from julia.utils import is_apple
 
+from .utils import skip_in_github_actions_windows
+
 PYJULIA_TEST_REBUILD = os.environ.get("PYJULIA_TEST_REBUILD", "no") == "yes"
 
 python_jl_required = pytest.mark.skipif(
@@ -67,6 +69,7 @@ def test_cli_quick_pass_no_julia(args):
 
 
 @python_jl_required
+@skip_in_github_actions_windows
 @pytest.mark.skipif(
     # This test makes sense only when PyJulia is importable by
     # `PyCall.python`.  Thus, it is safe to run this test only when

--- a/src/julia/tests/test_sysimage.py
+++ b/src/julia/tests/test_sysimage.py
@@ -3,12 +3,12 @@ import pytest
 from julia.sysimage import build_sysimage
 
 from .test_compatible_exe import runcode
-from .utils import only_in_ci, skip_in_appveyor
+from .utils import only_in_ci, skip_in_windows
 
 
 @pytest.mark.julia
 @only_in_ci
-@skip_in_appveyor  # Avoid "LVM ERROR: out of memory"
+@skip_in_windows
 def test_build_and_load(tmpdir, juliainfo):
     if juliainfo.version_info < (0, 7):
         pytest.skip("Julia < 0.7 is not supported")

--- a/src/julia/tests/test_sysimage.py
+++ b/src/julia/tests/test_sysimage.py
@@ -50,7 +50,7 @@ def test_build_and_load(tmpdir, juliainfo):
 
 @pytest.mark.julia
 @only_in_ci
-@skip_in_appveyor  # Avoid "LVM ERROR: out of memory"
+@skip_in_windows  # Avoid "LVM ERROR: out of memory"
 def test_build_with_basesysimage_and_load(tmpdir, juliainfo):
     skip_early_julia_versions(juliainfo)
 

--- a/src/julia/tests/utils.py
+++ b/src/julia/tests/utils.py
@@ -3,6 +3,7 @@ import os
 import pytest
 
 is_windows = os.name == "nt"
+in_github_actions = os.environ.get("GITHUB_ACTIONS", "false").lower() == "true"
 
 only_in_ci = pytest.mark.skipif(
     os.environ.get("CI", "false").lower() != "true", reason="CI=true not set"
@@ -14,4 +15,11 @@ Tests that are too destructive or slow to run with casual `tox` call.
 skip_in_windows = pytest.mark.skipif(is_windows, reason="Running in Windows")
 """
 Tests that are known to fail in Windows.
+"""
+
+skip_in_github_actions_windows = pytest.mark.skipif(
+    is_windows and in_github_actions, reason="Running in Windows in GitHub Actions"
+)
+"""
+Tests that are known to fail in Windows in GitHub Actions.
 """

--- a/src/julia/tests/utils.py
+++ b/src/julia/tests/utils.py
@@ -2,6 +2,8 @@ import os
 
 import pytest
 
+is_windows = os.name == "nt"
+
 only_in_ci = pytest.mark.skipif(
     os.environ.get("CI", "false").lower() != "true", reason="CI=true not set"
 )
@@ -9,9 +11,7 @@ only_in_ci = pytest.mark.skipif(
 Tests that are too destructive or slow to run with casual `tox` call.
 """
 
-skip_in_appveyor = pytest.mark.skipif(
-    os.environ.get("APPVEYOR", "false").lower() == "true", reason="APPVEYOR=true is set"
-)
+skip_in_windows = pytest.mark.skipif(is_windows, reason="Running in Windows")
 """
-Tests that are known to fail in AppVeyor.
+Tests that are known to fail in Windows.
 """

--- a/tox.ini
+++ b/tox.ini
@@ -39,6 +39,9 @@ passenv =
     # https://www.appveyor.com/docs/environment-variables/
     APPVEYOR
 
+    # https://docs.github.com/en/actions/configuring-and-managing-workflows/using-environment-variables#default-environment-variables
+    GITHUB_ACTIONS
+
     CI
 
 [pytest]


### PR DESCRIPTION
Run tests on GitHub Actions for

* Python 3.7, 3.8
* Julia 1.3, 1.5
* Linux, macOS, Windows

(with some combinations excluded)

Let's keep AppVeyor for now since there is one test that fails on GitHub (so it's skipped for now) but not in AppVeyor.  Also keeping Travis for now since the CI is pretty fragile...
