### PR TITLE
correct the way of finding Python's scripts folder

### DIFF
--- a/src/julia/tools.py
+++ b/src/julia/tools.py
@@ -139,7 +139,9 @@ def julia_py_executable(executable=sys.executable):
     """
     Path to ``julia-py`` executable installed for this Python executable.
     """
-    stempath = os.path.join(os.path.dirname(executable), "julia-py")
+    import sysconfig
+    stempath = sysconfig.get_path('scripts')
+    stempath = os.path.join(stempath, 'julia-py')
     candidates = {os.path.basename(p): p for p in glob.glob(stempath + "*")}
     if not candidates:
         raise RuntimeError(

--- a/src/julia/tools.py
+++ b/src/julia/tools.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, print_function
 
+import sysconfig
 import glob
 import os
 import re
@@ -135,11 +136,10 @@ def redirect_output_streams():
     # terminates the whole Python process.  Find out why.
 
 
-def julia_py_executable(executable=sys.executable):
+def julia_py_executable():
     """
     Path to ``julia-py`` executable installed for this Python executable.
     """
-    import sysconfig
     stempath = sysconfig.get_path('scripts')
     stempath = os.path.join(stempath, 'julia-py')
     candidates = {os.path.basename(p): p for p in glob.glob(stempath + "*")}

--- a/src/julia/tools.py
+++ b/src/julia/tools.py
@@ -1,11 +1,12 @@
 from __future__ import absolute_import, print_function
 
-import sysconfig
+
 import glob
 import os
 import re
 import subprocess
 import sys
+import sysconfig
 
 from .core import JuliaNotFound, which
 from .find_libpython import linked_libpython
@@ -140,13 +141,13 @@ def julia_py_executable():
     """
     Path to ``julia-py`` executable installed for this Python executable.
     """
-    stempath = sysconfig.get_path('scripts')
-    stempath = os.path.join(stempath, 'julia-py')
+    scripts_path = sysconfig.get_path('scripts')
+    stempath = os.path.join(scripts_path, 'julia-py')
     candidates = {os.path.basename(p): p for p in glob.glob(stempath + "*")}
     if not candidates:
         raise RuntimeError(
             "``julia-py`` executable is not found for Python installed at {}".format(
-                executable
+                scripts_path
             )
         )
 


### PR DESCRIPTION
When calling julia-py, `julia.core.julia_py_executable` is invoked, and currently works correctly for limited Unix distributions only. See

- https://github.com/python/cpython/blob/master/Lib/sysconfig.py
- https://github.com/python/cpython/blob/master/Doc/install/index.rst

I improved this, hence it shall then work for every OS supported by Python.
