### PR TITLE
Patch package_slug again in Julia >= 1.4

### DIFF
--- a/src/julia/patch.jl
+++ b/src/julia/patch.jl
@@ -24,6 +24,14 @@ else
                 return slug(crc, p)
             end
         end)
+    else
+        Base.eval(Base, quote
+            function package_slug(uuid::UUID, p::Int=5)
+                crc = _crc32c(uuid)
+                crc = _crc32c($julia_py, crc)
+                return slug(crc, p)
+            end
+        end)
     end
 
     # Monkey patch `Base.julia_exename`.


### PR DESCRIPTION
Not sure about this but I think I saw some problems that can be fixed by

    rm -fv ~/.julia/compiled/v1.4/PyCall/*.ji

It may still make sense to patch `package_slug`.