### PR TITLE
Two-stage system image monkey-patching for Julia 1.5

### DIFF
--- a/src/julia/compile.jl
+++ b/src/julia/compile.jl
@@ -51,3 +51,29 @@ else
 end
 
 @info "System image is created at $output"
+
+# Notes on two-stage system image monkey-patching for Julia 1.5
+#
+# Naive `@eval Base`-based monkey-patching stopped working as of Julia 1.5
+# presumably because @eval-ing to another module during precompilation now
+# throws an error: https://github.com/JuliaLang/julia/pull/35410
+#
+# We workaround this by creating the system image in two stages:
+#
+#   1.   The first stage is monkey-patching as done before but without
+#       PyCall. This way, we don't get the error because julia does not
+#       try to precompile any packages.
+#
+#   2.   The second stage is the inclusion of PyCall. At this point, we are
+#       in a monkey-patched system image. So, it's possible to precompile
+#       PyCall now.
+#
+# Note that even importing PackageCompiler.jl itself inside julia-py is
+# problematic because (normally) it has to be precompiled. We avoid this
+# problem by running PackageCompiler.jl under --compiled-modules=no. This is
+# safe to do thanks to PackageCompiler.do_ensurecompiled
+# (https://github.com/JuliaLang/PackageCompiler.jl/blob/3f0f4d882c560c4e4ccc6ab9a8b51ced380bb0d5/src/PackageCompiler.jl#L181-L188)
+# using a custom function PackageCompiler.get_julia_cmd
+# (https://github.com/JuliaLang/PackageCompiler.jl/blob/3f0f4d882c560c4e4ccc6ab9a8b51ced380bb0d5/src/PackageCompiler.jl#L113-L116)
+# (instead of Base.julia_cmd) and ignores --compiled-modules=no of the current
+# process.

--- a/src/julia/compile.jl
+++ b/src/julia/compile.jl
@@ -1,4 +1,4 @@
-compiler_env, script, output = ARGS
+compiler_env, script, output, base_sysimage = ARGS
 
 if VERSION < v"0.7-"
     error("Unsupported Julia version $VERSION")
@@ -26,6 +26,7 @@ create_sysimage(
     sysimage_path = output,
     project = ".",
     precompile_execution_file = script,
+    base_sysimage = isempty(base_sysimage) ? nothing : base_sysimage,
 )
 
 @info "System image is created at $output"

--- a/src/julia/compile.jl
+++ b/src/julia/compile.jl
@@ -20,13 +20,34 @@ Pkg.add([
     ),
 ])
 
-@info "Compiling system image..."
-create_sysimage(
-    [:PyCall],
-    sysimage_path = output,
-    project = ".",
-    precompile_execution_file = script,
-    base_sysimage = isempty(base_sysimage) ? nothing : base_sysimage,
-)
+if VERSION >= v"1.5-"
+    mktempdir() do dir
+        tmpimg = joinpath(dir, basename(output))
+        @info "Compiling a temporary system image without `PyCall`..."
+        create_sysimage(
+            Symbol[];
+            sysimage_path = tmpimg,
+            project = ".",
+            base_sysimage = isempty(base_sysimage) ? nothing : base_sysimage,
+        )
+        @info "Compiling system image..."
+        create_sysimage(
+            [:PyCall];
+            sysimage_path = output,
+            project = ".",
+            precompile_execution_file = script,
+            base_sysimage = tmpimg,
+        )
+    end
+else
+    @info "Compiling system image..."
+    create_sysimage(
+        [:PyCall],
+        sysimage_path = output,
+        project = ".",
+        precompile_execution_file = script,
+        base_sysimage = isempty(base_sysimage) ? nothing : base_sysimage,
+    )
+end
 
 @info "System image is created at $output"

--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -18,6 +18,7 @@ from __future__ import absolute_import, print_function
 import atexit
 import ctypes
 import ctypes.util
+import logging as _logging  # see `.logger`
 import os
 import sys
 import textwrap
@@ -73,11 +74,9 @@ def get_loghandler():
     """
     global _loghandler
     if _loghandler is None:
-        import logging  # see `.logger`
+        formatter = _logging.Formatter("%(levelname)s %(message)s")
 
-        formatter = logging.Formatter("%(levelname)s %(message)s")
-
-        _loghandler = logging.StreamHandler()
+        _loghandler = _logging.StreamHandler()
         _loghandler.setFormatter(formatter)
 
         logger.addHandler(_loghandler)
@@ -85,14 +84,16 @@ def get_loghandler():
 
 
 def set_loglevel(level):
-    import logging  # see `.logger`
-
     get_loghandler()
-    logger.setLevel(getattr(logging, level, level))
+    logger.setLevel(getattr(_logging, level, level))
 
 
 def enable_debug():
     set_loglevel("DEBUG")
+
+    handler = get_loghandler()
+    handler.setFormatter(_logging.Formatter("%(levelname)s (%(process)d) %(message)s"))
+
     logger.debug("")  # flush whatever in the line
     logger.debug("Debug-level logging is enabled for PyJulia.")
     logger.debug("PyJulia version: %s", __version__)

--- a/src/julia/install.jl
+++ b/src/julia/install.jl
@@ -57,6 +57,13 @@ function build_pycall()
             print(stderr, read(logfile, String))
         end
     end
+    depsfile = joinpath(pkgdir, "deps", "deps.jl")
+    if isfile(depsfile)
+        @info "`$depsfile`"
+        print(stderr, read(depsfile, String))
+    else
+        @error "Missing `deps.jl` file at: `$depsfile`"
+    end
 end
 
 if OP == "build"

--- a/src/julia/install.jl
+++ b/src/julia/install.jl
@@ -41,16 +41,21 @@ ENV["PYTHON"] = python
 # TODO: warn if some relevant JULIA_* environment variables are set
 # TODO: use PackageSpec to specify PyCall's UUID
 
-print_logfile = true
-
 function build_pycall()
+    modpath = Base.locate_package(pkgid)
+    pkgdir = joinpath(dirname(modpath), "..")
+
     if VERSION >= v"1.1.0-rc1"
         @info """Run `Pkg.build("PyCall"; verbose=true)`"""
         Pkg.build("PyCall"; verbose=true)
-        global print_logfile = false
     else
         @info """Run `Pkg.build("PyCall")`"""
         Pkg.build("PyCall")
+        logfile = joinpath(pkgdir, "deps", "build.log")
+        if isfile(logfile)
+            @info "Build log in $logfile"
+            print(stderr, read(logfile, String))
+        end
     end
 end
 
@@ -100,16 +105,5 @@ else
     else
         @info "Installing PyCall..."
         Pkg.add("PyCall")
-    end
-end
-
-modpath = Base.locate_package(pkgid)
-pkgdir = joinpath(dirname(modpath), "..")
-
-if print_logfile
-    logfile = joinpath(pkgdir, "deps", "build.log")
-    if isfile(logfile)
-        @info "Build log in $logfile"
-        print(stderr, read(logfile, String))
     end
 end

--- a/src/julia/julia_py.py
+++ b/src/julia/julia_py.py
@@ -64,10 +64,10 @@ def julia_py(julia, pyjulia_debug, jl_args):
         ):
             print("julia-py: Error while calling `Random.__init__()`", file=sys.stderr)
             sys.exit(code)
-        logger.debug("Loading %s", patch_jl_path)
-        if not api.jl_eval_string(b"""Base.include(Main, ENV["_PYJULIA_PATCH_JL"])"""):
-            print("julia-py: Error in", patch_jl_path, file=sys.stderr)
-            sys.exit(code)
+    logger.debug("Loading %s", patch_jl_path)
+    if not api.jl_eval_string(b"""Base.include(Main, ENV["_PYJULIA_PATCH_JL"])"""):
+        print("julia-py: Error in", patch_jl_path, file=sys.stderr)
+        sys.exit(code)
     logger.debug("Calling `Base._start()`")
     if api.jl_eval_string(b"Base.invokelatest(Base._start)"):
         code = 0

--- a/src/julia/julia_py.py
+++ b/src/julia/julia_py.py
@@ -27,6 +27,7 @@ logger = getLogger("julia")
 
 
 def julia_py(julia, pyjulia_debug, jl_args):
+    pyjulia_debug = True
     if pyjulia_debug:
         enable_debug()
 

--- a/src/julia/julia_py.py
+++ b/src/julia/julia_py.py
@@ -27,7 +27,6 @@ logger = getLogger("julia")
 
 
 def julia_py(julia, pyjulia_debug, jl_args):
-    pyjulia_debug = True
     if pyjulia_debug:
         enable_debug()
 

--- a/src/julia/julia_py.py
+++ b/src/julia/julia_py.py
@@ -83,6 +83,23 @@ class CustomFormatter(
 
 
 def is_pyjulia_in_julia_debug(julia_debug=os.environ.get("JULIA_DEBUG", "")):
+    """
+    Parse `JULIA_DEBUG` and return the debug flag.
+
+    >>> is_pyjulia_in_julia_debug("")
+    False
+    >>> is_pyjulia_in_julia_debug("Main,loading")
+    False
+    >>> is_pyjulia_in_julia_debug("pyjulia")
+    True
+    >>> is_pyjulia_in_julia_debug("all")
+    True
+    >>> is_pyjulia_in_julia_debug("all,!pyjulia")
+    False
+
+    Ref:
+    https://github.com/JuliaLang/julia/pull/32432
+    """
     syms = list(filter(None, map(str.strip, julia_debug.split(","))))
     if "pyjulia" in syms:
         return True

--- a/src/julia/julia_py.py
+++ b/src/julia/julia_py.py
@@ -65,7 +65,8 @@ def julia_py(julia, pyjulia_debug, jl_args):
             print("julia-py: Error while calling `Random.__init__()`", file=sys.stderr)
             sys.exit(code)
         logger.debug("Loading %s", patch_jl_path)
-        if api.jl_eval_string(b"""Base.include(Main, ENV["_PYJULIA_PATCH_JL"])"""):
+        if not api.jl_eval_string(b"""Base.include(Main, ENV["_PYJULIA_PATCH_JL"])"""):
+            print("julia-py: Error in", patch_jl_path, file=sys.stderr)
             sys.exit(code)
     logger.debug("Calling `Base._start()`")
     if api.jl_eval_string(b"Base.invokelatest(Base._start)"):

--- a/src/julia/julia_py.py
+++ b/src/julia/julia_py.py
@@ -71,8 +71,9 @@ def julia_py(julia, pyjulia_debug, jl_args):
     logger.debug("Calling `Base._start()`")
     if api.jl_eval_string(b"Base.invokelatest(Base._start)"):
         code = 0
-    logger.debug("Exiting with code %s", code)
+    logger.debug("Calling `jl_atexit_hook(%s)`", code)
     api.jl_atexit_hook(code)
+    logger.debug("Exiting with code %s", code)
     sys.exit(code)
 
 

--- a/src/julia/julia_py.py
+++ b/src/julia/julia_py.py
@@ -82,6 +82,15 @@ class CustomFormatter(
     pass
 
 
+def is_pyjulia_in_julia_debug(julia_debug=os.environ.get("JULIA_DEBUG", "")):
+    syms = list(filter(None, map(str.strip, julia_debug.split(","))))
+    if "pyjulia" in syms:
+        return True
+    elif "all" in syms and "!pyjulia" not in syms:
+        return True
+    return False
+
+
 def parse_args(args, **kwargs):
     options = dict(
         prog="julia-py",
@@ -101,8 +110,19 @@ def parse_args(args, **kwargs):
     parser.add_argument(
         "--pyjulia-debug",
         action="store_true",
+        default=is_pyjulia_in_julia_debug(),
         help="""
-        Print PyJulia's debugging messages to standard error.
+        Print PyJulia's debugging messages to standard error.  It is
+        automatically set if `pyjulia` is in the environment variable
+        `JULIA_DEBUG` (e.g., `JULIA_DEBUG=pyjulia,Main`).
+        """,
+    )
+    parser.add_argument(
+        "--no-pyjulia-debug",
+        dest="pyjulia_debug",
+        action="store_false",
+        help="""
+        Toggle off `--pyjulia_debug`.
         """,
     )
     ns, jl_args = parser.parse_known_args(args)

--- a/src/julia/julia_py.py
+++ b/src/julia/julia_py.py
@@ -65,8 +65,8 @@ def julia_py(julia, pyjulia_debug, jl_args):
             sys.exit(code)
         logger.debug("Loading %s", patch_jl_path)
         if api.jl_eval_string(b"""Base.include(Main, ENV["_PYJULIA_PATCH_JL"])"""):
-            logger.debug("Calling `Base._start()`")
             sys.exit(code)
+    logger.debug("Calling `Base._start()`")
     if api.jl_eval_string(b"Base.invokelatest(Base._start)"):
         code = 0
     logger.debug("Exiting with code %s", code)

--- a/src/julia/patch.jl
+++ b/src/julia/patch.jl
@@ -2,9 +2,9 @@ try
     julia_py = ENV["_PYJULIA_JULIA_PY"]
 
     if Base.julia_cmd().exec[1] == julia_py
-        @debug "Already monkey-patched. Skipping..." julia_py
+        @debug "Already monkey-patched. Skipping..." julia_py getpid()
     else
-        @debug "Monkey-patching..." julia_py
+        @debug "Monkey-patching..." julia_py getpid()
 
         # Monkey patch `Base.package_slug`
         #
@@ -53,9 +53,9 @@ try
         end)
         @assert Base.julia_cmd().exec[1] == julia_py
 
-        @debug "Successfully monkey-patched" julia_py
+        @debug "Successfully monkey-patched" julia_py getpid()
     end
 catch err
-    @error "Failed to monkey-patch `julia`" exception = (err, catch_backtrace())
+    @error "Failed to monkey-patch `julia`" exception = (err, catch_backtrace()) getpid()
     rethrow()
 end

--- a/src/julia/patch.jl
+++ b/src/julia/patch.jl
@@ -1,45 +1,53 @@
-julia_py = ENV["_PYJULIA_JULIA_PY"]
+try
+    julia_py = ENV["_PYJULIA_JULIA_PY"]
 
-if Base.julia_cmd().exec[1] == julia_py
-    @debug "Already monkey-patched. Skipping..." julia_py
-else
-    @debug "Monkey-patching..." julia_py
+    if Base.julia_cmd().exec[1] == julia_py
+        @debug "Already monkey-patched. Skipping..." julia_py
+    else
+        @debug "Monkey-patching..." julia_py
 
-    # Monkey patch `Base.package_slug`
-    #
-    # This is used for generating the set of precompilation cache paths
-    # for PyJulia different to the standard Julia runtime.
-    #
-    # See also:
-    # * Suggestion: Use different precompilation cache path for different
-    #   system image -- https://github.com/JuliaLang/julia/pull/29914
-    #
-    if VERSION < v"1.4.0-DEV.389"
+        # Monkey patch `Base.package_slug`
+        #
+        # This is used for generating the set of precompilation cache paths
+        # for PyJulia different to the standard Julia runtime.
+        #
+        # See also:
+        # * Suggestion: Use different precompilation cache path for different
+        #   system image -- https://github.com/JuliaLang/julia/pull/29914
+        #
+        if VERSION < v"1.4.0-DEV.389"
+            Base.eval(
+                Base,
+                quote
+                    function package_slug(uuid::UUID, p::Int = 5)
+                        crc = _crc32c(uuid)
+                        crc = _crc32c(unsafe_string(JLOptions().image_file), crc)
+                        crc = _crc32c(unsafe_string(JLOptions().julia_bin), crc)
+                        crc = _crc32c($julia_py, crc)
+                        return slug(crc, p)
+                    end
+                end,
+            )
+        end
+
+        # Monkey patch `Base.julia_exename`.
+        #
+        # This is required for propagating the monkey patches to subprocesses.
+        # This is important especially for the subprocesses used for
+        # precompilation.
+        #
+        # See also:
+        # * Request: Add an API for configuring julia_cmd --
+        #   https://github.com/JuliaLang/julia/pull/30065
+        #
         Base.eval(Base, quote
-            function package_slug(uuid::UUID, p::Int=5)
-                crc = _crc32c(uuid)
-                crc = _crc32c(unsafe_string(JLOptions().image_file), crc)
-                crc = _crc32c(unsafe_string(JLOptions().julia_bin), crc)
-                crc = _crc32c($julia_py, crc)
-                return slug(crc, p)
-            end
+            julia_exename() = $julia_py
         end)
+        @assert Base.julia_cmd().exec[1] == julia_py
+
+        @debug "Successfully monkey-patched" julia_py
     end
-
-    # Monkey patch `Base.julia_exename`.
-    #
-    # This is required for propagating the monkey patches to subprocesses.
-    # This is important especially for the subprocesses used for
-    # precompilation.
-    #
-    # See also:
-    # * Request: Add an API for configuring julia_cmd --
-    #   https://github.com/JuliaLang/julia/pull/30065
-    #
-    Base.eval(Base, quote
-        julia_exename() = $julia_py
-    end)
-    @assert Base.julia_cmd().exec[1] == julia_py
-
-    @debug "Successfully monkey-patched" julia_py
+catch err
+    @error "Failed to monkey-patch `julia`" exception = (err, catch_backtrace())
+    rethrow()
 end

--- a/src/julia/patch.jl
+++ b/src/julia/patch.jl
@@ -40,4 +40,6 @@ else
         julia_exename() = $julia_py
     end)
     @assert Base.julia_cmd().exec[1] == julia_py
+
+    @debug "Successfully monkey-patched" julia_py
 end

--- a/src/julia/sysimage.py
+++ b/src/julia/sysimage.py
@@ -25,7 +25,7 @@ from contextlib import contextmanager
 from logging import getLogger  # see `.core.logger`
 
 from .core import enable_debug
-from .tools import julia_py_executable
+from .tools import _julia_version, julia_py_executable
 
 logger = getLogger("julia.sysimage")
 
@@ -49,6 +49,8 @@ def install_packagecompiler_cmd(julia, compiler_env):
 
 def build_sysimage_cmd(julia_py, julia, compile_args):
     cmd = [julia_py, "--julia", julia]
+    if _julia_version(julia) >= (1, 5, 0):
+        cmd.append("--compiled-modules=no")
     if sys.stdout.isatty():
         cmd.append("--color=yes")
     cmd.append(script_path("compile.jl"))

--- a/src/julia/sysimage.py
+++ b/src/julia/sysimage.py
@@ -50,6 +50,7 @@ def install_packagecompiler_cmd(julia, compiler_env):
 def build_sysimage_cmd(julia_py, julia, compile_args):
     cmd = [julia_py, "--julia", julia]
     if _julia_version(julia) >= (1, 5, 0):
+        # Avoid precompiling PackageCompiler.jl. See the notes in compile.jl.
         cmd.append("--compiled-modules=no")
     if sys.stdout.isatty():
         cmd.append("--color=yes")

--- a/src/julia/sysimage.py
+++ b/src/julia/sysimage.py
@@ -76,6 +76,7 @@ def build_sysimage(
     script=script_path("precompile.jl"),
     debug=False,
     compiler_env="",
+    base_sysimage=None,
 ):
     if debug:
         enable_debug()
@@ -99,6 +100,8 @@ def build_sysimage(
             os.path.realpath(script),
             # output -- path to sys.o file
             os.path.realpath(output),
+            # optional base system image to build on
+            "" if base_sysimage is None else os.path.realpath(base_sysimage),
         ]
 
         check_call(build_sysimage_cmd(julia_py, julia, compile_args), cwd=path)
@@ -119,7 +122,7 @@ def main(args=None):
     parser.add_argument(
         "--script",
         default=script_path("precompile.jl"),
-        help="Path to Julia script with precopmile instructions.",
+        help="Path to Julia script with precompile instructions.",
     )
     parser.add_argument(
         "--compiler-env",
@@ -131,7 +134,14 @@ def main(args=None):
         is given.
         """,
     )
-    parser.add_argument("output", help="Path to system image file sys.o.")
+    parser.add_argument(
+        "--base-sysimage",
+        help="""
+        Path to a Julia system image to build on rather than the default
+        Julia system image.
+        """,
+    )
+    parser.add_argument("output", help="Path to new system image file sys.o.")
     ns = parser.parse_args(args)
     try:
         build_sysimage(**vars(ns))

--- a/src/julia/tests/test_sysimage.py
+++ b/src/julia/tests/test_sysimage.py
@@ -6,16 +6,12 @@ from .test_compatible_exe import runcode
 from .utils import only_in_ci, skip_in_appveyor
 
 
-@pytest.mark.julia
-@only_in_ci
-@skip_in_appveyor  # Avoid "LVM ERROR: out of memory"
-def test_build_and_load(tmpdir, juliainfo):
+def skip_early_julia_versions(juliainfo):
     if juliainfo.version_info < (1, 3, 1):
         pytest.skip("Julia < 1.3.1 is not supported")
 
-    sysimage_path = str(tmpdir.join("sys.so"))
-    build_sysimage(sysimage_path, julia=juliainfo.julia)
 
+def assert_sample_julia_code_runs(juliainfo, sysimage_path):
     very_random_string = "4903dc03-950f-4a54-98a3-c57a354b62df"
     proc = runcode(
         """
@@ -38,3 +34,30 @@ def test_build_and_load(tmpdir, juliainfo):
         )
     )
     assert very_random_string in proc.stdout
+
+
+@pytest.mark.julia
+@only_in_ci
+@skip_in_appveyor  # Avoid "LVM ERROR: out of memory"
+def test_build_and_load(tmpdir, juliainfo):
+    skip_early_julia_versions(juliainfo)
+
+    sysimage_path = str(tmpdir.join("sys.so"))
+    build_sysimage(sysimage_path, julia=juliainfo.julia)
+
+    assert_sample_julia_code_runs(juliainfo, sysimage_path)
+
+
+@pytest.mark.julia
+@only_in_ci
+@skip_in_appveyor  # Avoid "LVM ERROR: out of memory"
+def test_build_with_basesysimage_and_load(tmpdir, juliainfo):
+    skip_early_julia_versions(juliainfo)
+
+    sysimage_path = str(tmpdir.join("sys.so"))
+    base_sysimage_path = juliainfo.sysimage
+    build_sysimage(
+        sysimage_path, julia=juliainfo.julia, base_sysimage=base_sysimage_path
+    )
+
+    assert_sample_julia_code_runs(juliainfo, sysimage_path)

--- a/src/julia/tests/test_sysimage.py
+++ b/src/julia/tests/test_sysimage.py
@@ -6,6 +6,7 @@ import pytest
 
 from julia.sysimage import build_sysimage
 
+from ..tools import build_pycall
 from .test_compatible_exe import runcode
 from .utils import only_in_ci, skip_in_windows
 
@@ -48,6 +49,7 @@ def test_build_and_load(tmpdir, juliainfo, with_pycall_cache):
     skip_early_julia_versions(juliainfo)
 
     if with_pycall_cache:
+        build_pycall(julia=juliainfo.julia)
         check_call([juliainfo.julia, "--startup-file=no", "-e", "using PyCall"])
     else:
         # TODO: don't remove user's compile cache

--- a/src/julia/tools.py
+++ b/src/julia/tools.py
@@ -41,6 +41,11 @@ def _julia_version(julia):
         return (0, 0, 0)
 
 
+def build_pycall(julia="julia", python=sys.executable, **kwargs):
+    # Passing `python` to force build (OP="build")
+    install(julia=julia, python=python, **kwargs)
+
+
 def install(julia="julia", color="auto", python=None, quiet=False):
     """
     install(*, julia="julia", color="auto")

--- a/src/julia/tools.py
+++ b/src/julia/tools.py
@@ -33,7 +33,7 @@ Some useful information may also be stored in the build log file
 
 
 def _julia_version(julia):
-    output = subprocess.check_output(["julia", "--version"], universal_newlines=True)
+    output = subprocess.check_output([julia, "--version"], universal_newlines=True)
     match = re.search(r"([0-9]+)\.([0-9]+)\.([0-9]+)", output)
     if match:
         return tuple(int(match.group(i + 1)) for i in range(3))

--- a/src/julia/with_rebuilt.py
+++ b/src/julia/with_rebuilt.py
@@ -14,7 +14,7 @@ import sys
 from contextlib import contextmanager
 
 from .core import JuliaInfo
-from .tools import install
+from .tools import build_pycall
 
 # fmt: off
 
@@ -26,8 +26,7 @@ def maybe_rebuild(rebuild, julia):
 
         print('Building PyCall.jl with PYTHON =', sys.executable)
         sys.stdout.flush()
-        # Passing `python` to force build (OP="build")
-        install(julia=julia, python=sys.executable)
+        build_pycall(julia=julia, python=sys.executable)
         try:
             yield
         finally:
@@ -37,7 +36,7 @@ def maybe_rebuild(rebuild, julia):
                 python = str(info.python)
                 print()  # clear out messages from py.test
                 print('Restoring previous PyCall.jl build with PYTHON =', python)
-                install(julia=julia, python=python, quiet=True)
+                build_pycall(julia=julia, python=python, quiet=True)
     else:
         yield
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,6 +29,8 @@ passenv =
     PYJULIA_TEST_REBUILD
     PYJULIA_TEST_RUNTIME
 
+    JULIA_DEBUG
+
     # See: test/test_compatible_exe.py
     PYJULIA_TEST_INCOMPATIBLE_PYTHONS
 

--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ commands =
 
 setenv =
     PYJULIA_TEST_PYTHON_JL_IS_INSTALLED = yes
+    JULIA_DEBUG = all
 
 passenv =
     # Allow a workaround for "error initializing LibGit2 module":


### PR DESCRIPTION
`@eval Base`-based monkey-patching stopped working as of Julia 1.5 presumably because `@eval`-ing to another module during precompilation now throws an error: https://github.com/JuliaLang/julia/pull/35410

This PR workarounds this by creating the system image in two stages:

1. The first stage is monkey-patching as done before but without `PyCall`.  This way, we don't get the error because `julia` does not try to precompile any packages.

2. The second stage is the inclusion of `PyCall`.  At this point, we are in a monkey-patched system image.  So, it's possible to precompile `PyCall` now.

Note that even importing PackageCompiler.jl itself inside `julia-py` is problematic because (normally) it has to be precompiled.  We avoid this problem by running PackageCompiler.jl under `--compiled-modules=no`.  This is safe to do thanks to [`PackageCompiler.do_ensurecompiled`](https://github.com/JuliaLang/PackageCompiler.jl/blob/3f0f4d882c560c4e4ccc6ab9a8b51ced380bb0d5/src/PackageCompiler.jl#L181-L188) using a custom function [`PackageCompiler.get_julia_cmd`](https://github.com/JuliaLang/PackageCompiler.jl/blob/3f0f4d882c560c4e4ccc6ab9a8b51ced380bb0d5/src/PackageCompiler.jl#L113-L116) (instead of `Base.julia_cmd`) and ignores `--compiled-modules=no` of the current process.


fix #393
close #376