### PR TITLE
Setup Mergify

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,40 @@
+pull_request_rules:
+  - name: remove outdated reviews
+    conditions:
+      - base=master
+    actions:
+      dismiss_reviews: {}
+  - name: automatic squash-merge when CI passes
+    conditions:
+      - base=master
+      - "#approved-reviews-by>=1"
+      - label=ready-to-merge:squash
+      - label!=work-in-progress
+    actions:
+      merge:
+        method: squash
+  - name: automatic rebase-merge when CI passes
+    conditions:
+      - base=master
+      - "#approved-reviews-by>=1"
+      - label=ready-to-merge:rebase
+      - label!=work-in-progress
+    actions:
+      merge:
+        method: rebase
+  - name: automatic merge when CI passes
+    conditions:
+      - base=master
+      - "#approved-reviews-by>=1"
+      - label=ready-to-merge:merge
+      - label!=work-in-progress
+    actions:
+      merge:
+        method: merge
+  - name: automatically approve PR when pushed by me
+    conditions:
+      - author=tkf
+      - base=master
+      - label~=ready-to-merge:.*
+    actions:
+      review: {}


### PR DESCRIPTION
This PR sets up Mergify (mergify.io) bot so that PRs can be merged
automatically after the CI checks are all green.  I set up branch
protection rule in the GitHub web UI
https://github.com/JuliaPy/pyjulia/settings/branches
to list the CIs to be checked by the bot.