### PR TITLE
Use `Base.require` instead of `using` in more places

### DIFF
--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -32,7 +32,7 @@ from .juliainfo import JuliaInfo
 from .libjulia import UNBOXABLE_TYPES, LibJulia, get_inprocess_libjulia, get_libjulia
 from .options import JuliaOptions, options_docs
 from .release import __version__
-from .utils import is_windows
+from .utils import IMPORT_PYCALL, is_windows
 
 try:
     from shutil import which
@@ -500,7 +500,8 @@ class Julia(object):
 
         # Currently, PyJulia assumes that `Main.PyCall` exsits.  Thus, we need
         # to import `PyCall` again here in case `init_julia=False` is passed:
-        self._call(u"using PyCall")
+        self._call(IMPORT_PYCALL)
+        self._call(u"using .PyCall")
 
         # Whether we initialized Julia or not, we MUST create at least one
         # instance of PyObject and the convert function. Since these will be

--- a/src/julia/install-packagecompiler.jl
+++ b/src/julia/install-packagecompiler.jl
@@ -4,7 +4,8 @@ if VERSION < v"0.7-"
     error("Unsupported Julia version $VERSION")
 end
 
-using Pkg
+const Pkg =
+    Base.require(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"))
 
 function cat_build_log(pkg)
     modpath = Base.locate_package(pkg)
@@ -22,7 +23,7 @@ Pkg.activate(compiler_env)
 @info "Installing PackageCompiler..."
 
 Pkg.add([
-    PackageSpec(
+    Pkg.PackageSpec(
         name = "PackageCompiler",
         uuid = "9b87118b-4619-50d2-8e1e-99f35a4d4d9d",
         version = "1",

--- a/src/julia/install.jl
+++ b/src/julia/install.jl
@@ -9,11 +9,15 @@ if VERSION < v"0.7.0"
     error("Unsupported Julia version $VERSION")
 end
 
-using Pkg
-using InteractiveUtils
+const Pkg =
+    Base.require(Base.PkgId(Base.UUID("44cfe95a-1eb2-52ea-b672-e2afdf69b78f"), "Pkg"))
+const InteractiveUtils = Base.require(Base.PkgId(
+    Base.UUID("b77e0a4c-d291-57a0-90e8-8db25a27a240"),
+    "InteractiveUtils",
+))
 
 @info "Julia version info"
-versioninfo(verbose=true)
+InteractiveUtils.versioninfo(verbose=true)
 
 @info "Julia executable: $(Base.julia_cmd().exec[1])"
 
@@ -29,7 +33,7 @@ end
 
 try
     # `import PyCall` cannot be caught?
-    global PyCall = Base.require(Main, :PyCall)
+    global PyCall = Base.require(pkgid)
 catch err
     @error "`import PyCall` failed" exception=(err, catch_backtrace())
     global PyCall = DummyPyCall

--- a/src/julia/pyjulia_helper.jl
+++ b/src/julia/pyjulia_helper.jl
@@ -1,9 +1,16 @@
 module _PyJuliaHelper
 
-import REPL
-using PyCall
-using PyCall: pyeval_, Py_eval_input, Py_file_input
-using PyCall.MacroTools: isexpr, walk
+const REPL =
+    Base.require(Base.PkgId(Base.UUID("3fa0cd96-eef1-5676-8a61-b3b8758bbffb"), "REPL"))
+const PyCall =
+    Base.require(Base.PkgId(Base.UUID("438e738f-606a-5dbb-bf0a-cddfbfd45ab0"), "PyCall"))
+const MacroTools = Base.require(Base.PkgId(
+    Base.UUID("1914dd2f-81c6-5fcd-8719-6d5c9610ff09"),
+    "MacroTools",
+))
+
+using .PyCall: pyeval_, Py_eval_input, Py_file_input
+using .MacroTools: isexpr, walk
 
 """
     fullnamestr(m)

--- a/src/julia/pyjulia_helper.jl
+++ b/src/julia/pyjulia_helper.jl
@@ -9,7 +9,8 @@ const MacroTools = Base.require(Base.PkgId(
     "MacroTools",
 ))
 
-using .PyCall: pyeval_, Py_eval_input, Py_file_input
+using .PyCall
+using .PyCall: Py_eval_input, Py_file_input, pyeval_
 using .MacroTools: isexpr, walk
 
 """

--- a/src/julia/utils.py
+++ b/src/julia/utils.py
@@ -22,3 +22,9 @@ if is_windows:
     execprog = _execprog_subprocess
 else:
     execprog = _execprog_os
+
+
+PYCALL_PKGID = """\
+Base.PkgId(Base.UUID("438e738f-606a-5dbb-bf0a-cddfbfd45ab0"), "PyCall")"""
+
+IMPORT_PYCALL = "const PyCall = Base.require({})".format(PYCALL_PKGID)


### PR DESCRIPTION
## Commit Message
Use `Base.require` instead of `using` in more places (#407)

This way, PyJulia can work in more strict setup (e.g., customized
`JULIA_LOAD_PATH`).