### PR TITLE
Use protected branch instead of manual listing in .mergify.yml

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,3 +1,6 @@
+# [NOTE] This setting relies on "required status check":
+# https://docs.github.com/en/github/administering-a-repository/about-required-status-checks
+
 pull_request_rules:
   - name: remove outdated reviews
     conditions:
@@ -13,10 +16,28 @@ pull_request_rules:
     actions:
       merge:
         method: squash
+  - name: automatic squash-merge when CI passes (@tkf)
+    conditions:
+      - base=master
+      - author=tkf
+      - label=ready-to-merge:squash
+      - label!=work-in-progress
+    actions:
+      merge:
+        method: squash
   - name: automatic rebase-merge when CI passes
     conditions:
       - base=master
       - "#approved-reviews-by>=1"
+      - label=ready-to-merge:rebase
+      - label!=work-in-progress
+    actions:
+      merge:
+        method: rebase
+  - name: automatic rebase-merge when CI passes (@tkf)
+    conditions:
+      - base=master
+      - author=tkf
       - label=ready-to-merge:rebase
       - label!=work-in-progress
     actions:
@@ -31,10 +52,12 @@ pull_request_rules:
     actions:
       merge:
         method: merge
-  - name: automatically approve PR when pushed by me
+  - name: automatic merge when CI passes (@tkf)
     conditions:
-      - author=tkf
       - base=master
-      - label~=ready-to-merge:.*
+      - author=tkf
+      - label=ready-to-merge:merge
+      - label!=work-in-progress
     actions:
-      review: {}
+      merge:
+        method: merge


### PR DESCRIPTION
This is the setup I've using in other projects and it has been robust (e.g., https://github.com/JuliaFolds/Transducers.jl/blob/84af4ea1ab1d86034ffdbd686d37ef8966fa2b50/.mergify.yml). It seems to be better than using the stateful condition like approvals.