### PR TITLE
Fix test__using_default_setup with PYJULIA_TEST_RUNTIME

### DIFF
--- a/.github/workflows/testtests.yml
+++ b/.github/workflows/testtests.yml
@@ -1,0 +1,21 @@
+name: Test tests
+
+on:
+  push:
+    branches:
+      - master
+    tags: '*'
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  test__using_default_setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v1
+      - run: python -m pip install --upgrade tox
+      - run: python -m tox -- --no-julia -k test__using_default_setup
+        env:
+          PYJULIA_TEST_RUNTIME: dummy

--- a/src/julia/tests/test_plugin.py
+++ b/src/julia/tests/test_plugin.py
@@ -10,9 +10,10 @@ is_windows = os.name == "nt"
 userhome = os.path.expanduser("~")
 
 
-def test__using_default_setup(testdir, request):
+def test__using_default_setup(testdir, request, monkeypatch):
     if request.config.getoption("runpytest") != "subprocess":
         raise ValueError("Need `-p pytester --runpytest=subprocess` options.")
+    monkeypatch.delenv("PYJULIA_TEST_RUNTIME", raising=False)
 
     # create a temporary conftest.py file
     testdir.makeini(


### PR DESCRIPTION
## Commit Message
Fix test__using_default_setup with PYJULIA_TEST_RUNTIME (#420)

Before this patch,

    PYJULIA_TEST_RUNTIME=dummy tox -- --no-julia -k test__using_default_setup

did not work (which came up when I was writing
https://github.com/tkf/PyJuliaTester.jl).  It is fixed by removing
`PYJULIA_TEST_RUNTIME` in `test__using_default_setup`.