### PR TITLE
allow building sysimage with custom PyCall

### DIFF
--- a/src/julia/compile.jl
+++ b/src/julia/compile.jl
@@ -12,26 +12,27 @@ Pkg.activate(compiler_env)
 using PackageCompiler
 
 Pkg.activate(pycall_env)
-pycall = Pkg.PackageSpec(
-    name = "PyCall",
-    uuid = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0",
-)
-if !(pycall.uuid in keys(Pkg.dependencies()))
+if pycall_env == "."
     @info "Installing PyCall..."
-    Pkg.add([pycall])
+    Pkg.add([
+        Pkg.PackageSpec(
+            name = "PyCall",
+            uuid = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0",
+        ),
+    ])
 end
 
 if VERSION >= v"1.5-"
     mktempdir() do dir
         tmpimg = joinpath(dir, basename(output))
-        @info "Compiling a temporary system image without `PyCall`..."
+        @info "Compiling a temporary system image without PyCall..."
         create_sysimage(
             Symbol[];
             sysimage_path = tmpimg,
             project = pycall_env,
             base_sysimage = isempty(base_sysimage) ? nothing : base_sysimage,
         )
-        @info "Compiling system image with `PyCall` from $pycall_env..."
+        @info "Compiling system image with PyCall from $pycall_env..."
         create_sysimage(
             [:PyCall];
             sysimage_path = output,
@@ -41,7 +42,7 @@ if VERSION >= v"1.5-"
         )
     end
 else
-    @info "Compiling system image with `PyCall` from $pycall_env..."
+    @info "Compiling system image with PyCall from $pycall_env..."
     create_sysimage(
         [:PyCall],
         sysimage_path = output,

--- a/src/julia/sysimage.py
+++ b/src/julia/sysimage.py
@@ -101,7 +101,7 @@ def build_sysimage(
             check_call(install_packagecompiler_cmd(julia, compiler_env), cwd=path)
 
         if pycall_env:
-            pycall_env = os.path.abspath(".")
+            pycall_env = os.path.abspath(pycall_env)
         else:
             pycall_env = "."
 

--- a/src/julia/sysimage.py
+++ b/src/julia/sysimage.py
@@ -91,7 +91,7 @@ def build_sysimage(
     julia_py = julia_py_executable()
 
     with temporarydirectory(prefix="tmp.pyjulia.sysimage.") as path:
-        
+
         if compiler_env:
             compiler_env = os.path.abspath(compiler_env)
         else:
@@ -99,7 +99,7 @@ def build_sysimage(
             # Not using julia-py to install PackageCompiler to reduce
             # method re-definition warnings:
             check_call(install_packagecompiler_cmd(julia, compiler_env), cwd=path)
-            
+
         if pycall_env:
             pycall_env = os.path.abspath(".")
         else:


### PR DESCRIPTION
The current sysimage just installs the latest PyCall from the registry. This adds a `--pycall-env` option which lets you bake in an existing one from any project you want, 

```shell
$ python -m julia.sysimage --pycall-env . sys.so # take PyCall from the project in the current folder
```

I found this useful in my debugging  / developing, and I think it'd be nice to have in the official repo. 