### PR TITLE
Fix julia library jl_init_with_image bug

### DIFF
--- a/src/julia/libjulia.py
+++ b/src/julia/libjulia.py
@@ -237,10 +237,13 @@ class LibJulia(BaseLibJulia):
 
     @property
     def jl_init_with_image(self):
-        try:
-            return self.libjulia.jl_init_with_image
+        try: 
+            try:
+                return self.libjulia.jl_init_with_image
+            except AttributeError:
+                return self.libjulia.jl_init_with_image__threading
         except AttributeError:
-            return self.libjulia.jl_init_with_image__threading
+            return self.libjulia.jl_init__threading
 
     def init_julia(self, options=None):
         """


### PR DESCRIPTION
A possible solution to #437 

`jl_init_with_image` and `jl_init_with_image__threading` are no longer exposed functions in the Julia 1.6 library, whereas `jl_init__threading` seems to work.

