### PR TITLE
fix `sysimage` argument to `julia.core.Julia.__init__`

### DIFF
--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -478,8 +478,14 @@ class Julia(object):
 
             is_compatible_python = jlinfo.is_compatible_python()
             logger.debug("is_compatible_python = %r", is_compatible_python)
+            use_custom_sysimage = options.sysimage is not None
+            logger.debug("use_custom_sysimage = %r", use_custom_sysimage)
             logger.debug("compiled_modules = %r", options.compiled_modules)
-            if not (options.compiled_modules == "no" or is_compatible_python):
+            if not (
+                options.compiled_modules == "no"
+                or is_compatible_python
+                or use_custom_sysimage
+            ):
                 raise UnsupportedPythonError(jlinfo)
 
             self.api.init_julia(options)


### PR DESCRIPTION
On `master` branch, it should be possible to pass a custom "sysimage" to the `julia.core.Julia.__init__` method. However, if the python version in use is statically linked, an UnsupportedPythonError is thrown (despite the sysimage argument having been passed to `__init__`).

This commit prevents the UnsupportedPythonError from being thrown if a sysimage keyword argument is passed to `__init__`.
Closes #421.