### PR TITLE
 support for "threads" and "min-optlevel" julia options

### DIFF
--- a/src/julia/options.py
+++ b/src/julia/options.py
@@ -113,6 +113,9 @@ warn_overwrite: {True, False, 'yes', 'no'}
 
 min_optlevel: {0, 1, 2, 3}
     Lower bound on the optimization level.
+
+threads: int or "auto"
+    How many threads to use.
 """
 
 

--- a/src/julia/options.py
+++ b/src/julia/options.py
@@ -49,7 +49,7 @@ class IntEtc(OptionDescriptor):
     def __set__(self, instance, value):
         if instance is None:
             raise AttributeError(self.name)
-        elif value in self.default or isinstance(value, int):
+        elif value in {None, *self.default} or isinstance(value, int):
             setattr(instance, self.dataname, value)
         else:
             if self.default:
@@ -205,7 +205,9 @@ class JuliaOptions(object):
     def as_args(self):
         args = []
         for (desc, value) in self.specified():
-            if len(desc.cli_argument_name()) == 1:
+            if value is None:
+                ...
+            elif len(desc.cli_argument_name()) == 1:
                 args.append(desc.cli_argument_name() + str(value))
             else:
                 args.append(desc.cli_argument_name() + "=" + str(value))

--- a/src/julia/options.py
+++ b/src/julia/options.py
@@ -110,6 +110,9 @@ sysimage: str
 
 warn_overwrite: {True, False, 'yes', 'no'}
     Enable or disable method overwrite warnings.
+
+min_optlevel: {0, 1, 2, 3}
+    Lower bound on the optimization level.
 """
 
 

--- a/src/julia/options.py
+++ b/src/julia/options.py
@@ -134,9 +134,11 @@ class JuliaOptions(object):
     compile = Choices("compile", yes_no_etc("all", "min"))
     depwarn = Choices("depwarn", yes_no_etc("error"))
     warn_overwrite = Choices("warn_overwrite", yes_no_etc())
+    min_optlevel = Choices("min_optlevel", dict(zip(range(4), map(str, range(4)))))
     optimize = Choices("optimize", dict(zip(range(4), map(str, range(4)))))
     inline = Choices("inline", yes_no_etc())
     check_bounds = Choices("check_bounds", yes_no_etc())
+    threads = Choices("threads", dict(zip(range(12), map(str, range(12)))))
 
     def __init__(self, **kwargs):
         unsupported = []
@@ -168,8 +170,10 @@ class JuliaOptions(object):
     def as_args(self):
         args = []
         for (desc, value) in self.specified():
-            args.append(desc.cli_argument_name())
-            args.append(value)
+            if len(desc.cli_argument_name()) == 1:
+                args.append(desc.cli_argument_name() + str(value))
+            else:
+                args.append(desc.cli_argument_name()+"="+str(value))
         return args
 
     @classmethod

--- a/src/julia/options.py
+++ b/src/julia/options.py
@@ -134,7 +134,7 @@ class JuliaOptions(object):
     compile = Choices("compile", yes_no_etc("all", "min"))
     depwarn = Choices("depwarn", yes_no_etc("error"))
     warn_overwrite = Choices("warn_overwrite", yes_no_etc())
-    optimize = Choices("optimize", dict(zip(range(4), range(4))))
+    optimize = Choices("optimize", dict(zip(range(4), map(str, range(4)))))
     inline = Choices("inline", yes_no_etc())
     check_bounds = Choices("check_bounds", yes_no_etc())
 

--- a/src/julia/options.py
+++ b/src/julia/options.py
@@ -49,16 +49,25 @@ class IntEtc(OptionDescriptor):
     def __set__(self, instance, value):
         if instance is None:
             raise AttributeError(self.name)
-        elif value in {None, *self.default} or isinstance(value, int):
+        elif value in self.default or isinstance(value, int):
             setattr(instance, self.dataname, value)
         else:
-            part = f" or {self.default}" if self.default else ""
+            if self.default:
+                part = " or " + " ".join(map(str, self.default))
+            else:
+                part = ""
             raise ValueError(
                 f"Option {self.name} only accepts integers{part}. Got: {value}"
             )
 
     def _domain(self):
         return {int, *self.default}
+
+    def cli_argument_spec(self):
+        return dict(
+            super(IntEtc, self).cli_argument_spec(),
+            choices=list(self.default) + ["1", "2", "3", "..."],
+        )
 
 
 class Choices(OptionDescriptor):

--- a/src/julia/tests/test_compatible_exe.py
+++ b/src/julia/tests/test_compatible_exe.py
@@ -23,7 +23,7 @@ def discover_other_pythons():
         [sys.executable, "--version"], universal_newlines=True, stderr=subprocess.STDOUT
     )
 
-    candidate_names = ["python", "python2", "python2.7", "python3"] + [
+    candidate_names = ["python", "python3"] + [
         "python3.{}".format(i) for i in range(20)
     ]
     found = {}

--- a/src/julia/tests/test_juliaoptions.py
+++ b/src/julia/tests/test_juliaoptions.py
@@ -7,13 +7,13 @@ from julia.core import JuliaOptions
 @pytest.mark.parametrize("kwargs, args", [
     ({}, []),
     (dict(compiled_modules=None), []),
-    (dict(compiled_modules=False), ["--compiled-modules", "no"]),
-    (dict(compiled_modules="no"), ["--compiled-modules", "no"]),
-    (dict(depwarn="error"), ["--depwarn", "error"]),
-    (dict(sysimage="PATH"), ["--sysimage", "PATH"]),
-    (dict(optimize=3), ["--optimize", "3"]),
-    (dict(threads=4), ["--threads", "4"]),
-    (dict(min_optlevel=2), ["--min-optlevel", "2"]),
+    (dict(compiled_modules=False), ["--compiled-modules=no"]),
+    (dict(compiled_modules="no"), ["--compiled-modules=no"]),
+    (dict(depwarn="error"), ["--depwarn=error"]),
+    (dict(sysimage="PATH"), ["--sysimage=PATH"]),
+    (dict(optimize=3), ["--optimize=3"]),
+    (dict(threads=4), ["--threads=4"]),
+    (dict(min_optlevel=2), ["--min-optlevel=2"]),
 ])
 # fmt: on
 def test_as_args(kwargs, args):

--- a/src/julia/tests/test_juliaoptions.py
+++ b/src/julia/tests/test_juliaoptions.py
@@ -14,6 +14,9 @@ from julia.core import JuliaOptions
     (dict(optimize=3), ["--optimize=3"]),
     (dict(threads=4), ["--threads=4"]),
     (dict(min_optlevel=2), ["--min-optlevel=2"]),
+    (dict(threads="auto", optimize=3), ["--optimize=3", '--threads=auto']),
+    (dict(optimize=3, threads="auto"), ["--optimize=3", '--threads=auto']),  # passed order doesn't matter
+    (dict(compiled_modules=None, depwarn="yes"), ["--depwarn=yes"]),
 ])
 # fmt: on
 def test_as_args(kwargs, args):

--- a/src/julia/tests/test_juliaoptions.py
+++ b/src/julia/tests/test_juliaoptions.py
@@ -11,7 +11,7 @@ from julia.core import JuliaOptions
     (dict(compiled_modules="no"), ["--compiled-modules", "no"]),
     (dict(depwarn="error"), ["--depwarn", "error"]),
     (dict(sysimage="PATH"), ["--sysimage", "PATH"]),
-    (dict(bindir="PATH"), ["--home", "PATH"]),
+    (dict(optimize=3), ["--optimize", "3"]),
 ])
 # fmt: on
 def test_as_args(kwargs, args):

--- a/src/julia/tests/test_juliaoptions.py
+++ b/src/julia/tests/test_juliaoptions.py
@@ -12,6 +12,8 @@ from julia.core import JuliaOptions
     (dict(depwarn="error"), ["--depwarn", "error"]),
     (dict(sysimage="PATH"), ["--sysimage", "PATH"]),
     (dict(optimize=3), ["--optimize", "3"]),
+    (dict(threads=4), ["--threads", "4"]),
+    (dict(min_optlevel=2), ["--min-optlevel", "2"]),
 ])
 # fmt: on
 def test_as_args(kwargs, args):

--- a/src/julia/tests/test_options.py
+++ b/src/julia/tests/test_options.py
@@ -26,6 +26,8 @@ def test_options_docs():
 
 
 def test_parse_jl_options():
-    opts = parse_jl_options(["--home", "/home", "--sysimage", "/sys/image", "--optimize", "3"])
+    opts = parse_jl_options(
+        ["--home", "/home", "--sysimage", "/sys/image", "--optimize", "3"]
+    )
     assert opts.home == "/home"
     assert opts.sysimage == "/sys/image"

--- a/src/julia/tests/test_options.py
+++ b/src/julia/tests/test_options.py
@@ -1,4 +1,4 @@
-from julia.options import JuliaOptions, options_docs
+from julia.options import JuliaOptions, options_docs, parse_jl_options
 
 
 def parse_options_docs(docs):
@@ -23,3 +23,9 @@ def test_options_docs():
         odef = optdefs.pop(desc.name)
         assert odef["domain"] == desc._domain()
     assert not optdefs
+
+
+def test_parse_jl_options():
+    opts = parse_jl_options(["--home", "/home", "--sysimage", "/sys/image", "--optimize", "3"])
+    assert opts.home == "/home"
+    assert opts.sysimage == "/sys/image"


### PR DESCRIPTION
Added support for "threads" and "min-optlevel" julia options.

Now all long opts are generated with "--arg=val" instead of "--arg val" since julia required arguments support both syntaxes, but optional arguments require the first one
