### PR TITLE
Fix CI test suite and and remove Python 2.7 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,6 @@ jobs:
           - '1.6'
           - '1.7'
           - '1.8'
-          - 'nightly'
         exclude:
           - os: ubuntu-latest
             architecture: x86

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,7 +24,8 @@ jobs:
         julia-version:
           - '1.0'
           - '1.6'
-          - '~1.7.0-rc1'
+          - '1.7'
+          - '1.8'
           - 'nightly'
         exclude:
           - os: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,15 +56,6 @@ jobs:
             architecture: x64
             python-version: '3.8'
             julia-version: '1'
-          # Python 2.7 (TODO: drop):
-          - os: ubuntu-latest
-            architecture: x64
-            python-version: '2.7'
-            julia-version: '1'
-          - os: windows-latest
-            architecture: x64
-            python-version: '2.7'
-            julia-version: '1'
       fail-fast: false
     name: Test ${{ matrix.os }} ${{ matrix.architecture }}
       Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,9 +35,6 @@ jobs:
           - os: macos-latest
             julia-version: '1.6'
           - os: windows-latest
-            architecture: x86
-            python-version: '3.10'  # not added yet?
-          - os: windows-latest
             julia-version: '1.6'
           - os: macos-latest
             julia-version: 'nightly'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,9 +55,10 @@ jobs:
             python-version: '3.8'
             julia-version: '1'
       fail-fast: false
-    name: Test ${{ matrix.os }} ${{ matrix.architecture }}
-      Python ${{ matrix.python-version }}
-      Julia ${{ matrix.julia-version }}
+    name: Test 
+      py${{ matrix.python-version }}
+      jl${{ matrix.julia-version }}
+      ${{ matrix.os }} ${{ matrix.architecture }}
     steps:
       - uses: actions/checkout@v1
       - name: Setup python

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -5,9 +5,9 @@ Welcome to PyJulia’s documentation!
 
 Experimenting with developing a better interface to
 `Julia language <https://julialang.org/>`_ that works with
-`Python <https://www.python.org/>`_ 2 & 3 and Julia v1.0+.
+`Python <https://www.python.org/>`_ 3 and Julia v1.0+.
 
-PyJulia is tested against Python versions 2.7, 3.5, 3.6, and 3.7.
+PyJulia is tested against Python versions 3.5+
 
 .. toctree::
    :maxdepth: 2

--- a/setup.py
+++ b/setup.py
@@ -59,8 +59,6 @@ setup(name='julia',
 
         # Specify the Python versions you support here. In particular, ensure
         # that you indicate whether you support Python 2, Python 3 or both.
-        'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
@@ -79,6 +77,7 @@ setup(name='julia',
       packages=find_packages("src"),
       package_dir={"": "src"},
       package_data={"julia": ["*.jl"]},
+      python_requires=">=3.4",
       extras_require={
           # Update `ci/test-upload/tox.ini` when "test" is changed:
           "test": [

--- a/src/julia/libjulia.py
+++ b/src/julia/libjulia.py
@@ -216,12 +216,6 @@ class LibJulia(BaseLibJulia):
                 'Julia library ("libjulia") not found! {}'.format(libjulia_path)
             )
 
-        # fixes a specific issue with python 2.7.13
-        # ctypes.windll.LoadLibrary refuses unicode argument
-        # http://bugs.python.org/issue29294
-        if sys.version_info >= (2, 7, 13) and sys.version_info < (2, 7, 14):
-            libjulia_path = libjulia_path.encode("ascii")
-
         with self._pathhack():
             self.libjulia = ctypes.PyDLL(libjulia_path, ctypes.RTLD_GLOBAL)
 

--- a/src/julia/magic.py
+++ b/src/julia/magic.py
@@ -49,8 +49,7 @@ except ImportError:
 
 @magics_class
 class JuliaMagics(Magics):
-    """A set of magics useful for interactive work with Julia.
-    """
+    """A set of magics useful for interactive work with Julia."""
 
     highlight = Bool(
         True,
@@ -118,10 +117,9 @@ class JuliaMagics(Magics):
         # IPython module. This seems to work with IPython back to ~v5, and
         # is at least somewhat immune to future IPython internals changes,
         # although by no means guaranteed to be perfect.
-        while (
-            caller_frame.f_globals.get("__name__").startswith("IPython")
-            or caller_frame.f_globals.get("__name__").startswith("julia")
-        ):
+        while caller_frame.f_globals.get("__name__").startswith(
+            "IPython"
+        ) or caller_frame.f_globals.get("__name__").startswith("julia"):
             caller_frame = caller_frame.f_back
 
         return_value = "nothing" if src.strip().endswith(";") else ""

--- a/src/julia/magic.py
+++ b/src/julia/magic.py
@@ -19,6 +19,7 @@ Usage
 
 from __future__ import absolute_import, print_function
 
+import inspect
 import sys
 import warnings
 
@@ -109,12 +110,18 @@ class JuliaMagics(Magics):
         """
         src = unicode(line if cell is None else cell)
 
+        caller_frame = inspect.currentframe()
+        if caller_frame is None:
+            caller_frame = sys._getframe(3)  # May not work.
+
         # We assume the caller's frame is the first parent frame not in the
         # IPython module. This seems to work with IPython back to ~v5, and
         # is at least somewhat immune to future IPython internals changes,
         # although by no means guaranteed to be perfect.
-        caller_frame = sys._getframe(3)
-        while caller_frame.f_globals.get("__name__").startswith("IPython"):
+        while (
+            caller_frame.f_globals.get("__name__").startswith("IPython")
+            or caller_frame.f_globals.get("__name__").startswith("julia")
+        ):
             caller_frame = caller_frame.f_back
 
         return_value = "nothing" if src.strip().endswith(";") else ""

--- a/src/julia/magic.py
+++ b/src/julia/magic.py
@@ -117,9 +117,12 @@ class JuliaMagics(Magics):
         # IPython module. This seems to work with IPython back to ~v5, and
         # is at least somewhat immune to future IPython internals changes,
         # although by no means guaranteed to be perfect.
-        while caller_frame.f_globals.get("__name__").startswith(
-            "IPython"
-        ) or caller_frame.f_globals.get("__name__").startswith("julia"):
+        while any(
+            (
+                caller_frame.f_globals.get("__name__").startswith("IPython"),
+                caller_frame.f_globals.get("__name__").startswith("julia"),
+            )
+        ):
             caller_frame = caller_frame.f_back
 
         return_value = "nothing" if src.strip().endswith(";") else ""

--- a/src/julia/pytestplugin.py
+++ b/src/julia/pytestplugin.py
@@ -125,7 +125,7 @@ def pytest_configure(config):
 
 @pytest.fixture(scope="session")
 def julia(request):
-    """ pytest fixture for providing a `Julia` instance. """
+    """pytest fixture for providing a `Julia` instance."""
     if not request.config.getoption("julia"):
         pytest.skip("--no-julia is given.")
 
@@ -136,7 +136,7 @@ def julia(request):
 
 @pytest.fixture(scope="session")
 def juliainfo(julia):
-    """ pytest fixture for providing `JuliaInfo` instance. """
+    """pytest fixture for providing `JuliaInfo` instance."""
     return _JULIA_INFO
 
 

--- a/src/julia/tests/conftest.py
+++ b/src/julia/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture(scope="session")
 def Main(julia):
-    """ pytest fixture for providing a Julia `Main` name space. """
+    """pytest fixture for providing a Julia `Main` name space."""
     from julia import Main
 
     return Main

--- a/src/julia/tests/test_core.py
+++ b/src/julia/tests/test_core.py
@@ -37,7 +37,7 @@ def test_call_error(julia):
 
 
 def test_call_julia_function_with_python_args(Main):
-    assert list(Main.map(Main.uppercase, array.array("u", [u"a", u"b", u"c"]))) == [
+    assert list(Main.map(Main.uppercase, array.array("u", ["a", "b", "c"]))) == [
         "A",
         "B",
         "C",
@@ -129,7 +129,7 @@ def test_getattr_submodule(Main):
 def test_star_import_julia_module(julia, tmp_path):
     # Create a Python module __pyjulia_star_import_test
     path = tmp_path / "__pyjulia_star_import_test.py"
-    path.write_text(u"from julia.Base.Enums import *")
+    path.write_text("from julia.Base.Enums import *")
     sys.path.insert(0, str(tmp_path))
 
     import __pyjulia_star_import_test

--- a/src/julia/tests/test_juliaoptions.py
+++ b/src/julia/tests/test_juliaoptions.py
@@ -18,10 +18,13 @@ def test_as_args(kwargs, args):
     assert JuliaOptions(**kwargs).as_args() == args
 
 
-@pytest.mark.parametrize("kwargs", [
-    dict(compiled_modules="invalid value"),
-    dict(bindir=123456789),
-])
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(compiled_modules="invalid value"),
+        dict(bindir=123456789),
+    ],
+)
 def test_valueerror(kwargs):
     with pytest.raises(ValueError) as excinfo:
         JuliaOptions(**kwargs)

--- a/src/julia/tests/test_magic.py
+++ b/src/julia/tests/test_magic.py
@@ -116,7 +116,6 @@ def test_type_conversion(run_cell):
     %julia py"1" isa Integer && py"1"o isa PyObject
     """) == True
 
-@pytest.mark.skip(reason="Incompatible with new IPython.")
 def test_local_scope(run_cell):
     assert run_cell("""
     x = "global"

--- a/src/julia/tests/test_magic.py
+++ b/src/julia/tests/test_magic.py
@@ -116,6 +116,7 @@ def test_type_conversion(run_cell):
     %julia py"1" isa Integer && py"1"o isa PyObject
     """) == True
 
+@pytest.mark.skip(reason="Incompatible with new IPython.")
 def test_local_scope(run_cell):
     assert run_cell("""
     x = "global"
@@ -125,7 +126,7 @@ def test_local_scope(run_cell):
         return ret
     f()
     """) == "local"
-    
+
 def test_global_scope(run_cell):
     assert run_cell("""
     x = "global"

--- a/src/julia/tests/test_runtests.py
+++ b/src/julia/tests/test_runtests.py
@@ -7,7 +7,7 @@ from .test_compatible_exe import run
 
 def test_runtests_failure(tmp_path):
     testfile = tmp_path / "test.py"
-    testcode = u"""
+    testcode = """
     def test_THIS_TEST_MUST_FAIL():
         assert False
     """

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@ envlist = py3
 [testenv]
 deps =
     pytest-cov
-    coverage < 5
+    coverage < 6
 extras =
     test
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -79,7 +79,7 @@ changedir = {toxinidir}/docs
 [testenv:style]
 deps =
     isort == 4.3.17
-    black == 19.3b0
+    black == 22.3.0
 commands =
     isort --recursive --check-only .
     black . {posargs:--check --diff}


### PR DESCRIPTION
The fix for the unittests turned out to just be upgrading Python's `coverage` tool to 5+, as version 4 was still using HTTP links.

@tkf or @mkitti could one of you review this? Once merged this will let us test the other PRs.

This also drops testing for Python 2.7 which is long deprecated and for which all use should be discouraged (since they stopped doing security patches in the end of 2019).