### PR TITLE
adding the trace-compile option to the julia initialization

### DIFF
--- a/src/julia/options.py
+++ b/src/julia/options.py
@@ -174,6 +174,7 @@ class JuliaOptions(object):
     inline = Choices("inline", yes_no_etc())
     check_bounds = Choices("check_bounds", yes_no_etc())
     threads = IntEtc("threads", etc={"auto"})
+    trace_compile = String("trace-compile")
 
     def __init__(self, **kwargs):
         unsupported = []

--- a/src/julia/options.py
+++ b/src/julia/options.py
@@ -145,6 +145,9 @@ min_optlevel: {0, 1, 2, 3}
 
 threads: {int, 'auto'}
     How many threads to use.
+
+trace_compile: str
+    Trace precompile statements during execution to the given file.
 """
 
 
@@ -174,7 +177,7 @@ class JuliaOptions(object):
     inline = Choices("inline", yes_no_etc())
     check_bounds = Choices("check_bounds", yes_no_etc())
     threads = IntEtc("threads", etc={"auto"})
-    trace_compile = String("trace-compile")
+    trace_compile = String("trace_compile")
 
     def __init__(self, **kwargs):
         unsupported = []

--- a/src/julia/tests/test_trace_compile.py
+++ b/src/julia/tests/test_trace_compile.py
@@ -25,5 +25,9 @@ def test_trace_file_created(tmpdir):
     # check whether the sin precompilation directive is included in the file
     trace_compile_content = Path(trace_compile_path).read_text().strip()
     lines = [x for x in trace_compile_content.split("\n") if len(x) > 0]
-    expected_precompile_line = r"precompile\(Tuple\{typeof\([A-Za-z]+\.sin\), Float64\}\)"
-    assert any([re.match(expected_precompile_line, x) is not None for x in lines])
+    expected_precompile_line = (
+        r"precompile\(Tuple\{typeof\([A-Za-z]+\.sin\), Float64\}\)"
+    )
+    assert any(
+        [re.match(expected_precompile_line, x) is not None for x in lines]
+    )

--- a/src/julia/tests/test_trace_compile.py
+++ b/src/julia/tests/test_trace_compile.py
@@ -28,6 +28,4 @@ def test_trace_file_created(tmpdir):
     expected_precompile_line = (
         r"precompile\(Tuple\{typeof\([A-Za-z]+\.sin\), Float64\}\)"
     )
-    assert any(
-        [re.match(expected_precompile_line, x) is not None for x in lines]
-    )
+    assert any([re.match(expected_precompile_line, x) is not None for x in lines])

--- a/src/julia/tests/test_trace_compile.py
+++ b/src/julia/tests/test_trace_compile.py
@@ -1,0 +1,23 @@
+import os
+from pathlib import Path
+from subprocess import check_call
+
+import pytest
+
+from .test_compatible_exe import runcode
+
+
+def test_trace_file_created(tmpdir):
+    currdir = os.getcwd()
+    os.chdir(str(tmpdir))
+    runcode(
+        """
+    from julia.api import Julia
+    jl = Julia(trace_compile="trace_compile.jl")
+
+    from julia import Main
+    Main.sin(2.0)
+    """
+    )
+    os.chdir(currdir)
+    assert (Path(tmpdir) / "trace_compile.jl").exists()

--- a/src/julia/tests/test_trace_compile.py
+++ b/src/julia/tests/test_trace_compile.py
@@ -5,8 +5,10 @@ from subprocess import check_call
 import pytest
 
 from .test_compatible_exe import runcode
+from .utils import skip_in_windows
 
 
+@skip_in_windows
 def test_trace_file_created(tmpdir):
     trace_compile_path = Path(tmpdir) / "trace_compile.jl"
     runcode(

--- a/src/julia/tests/test_trace_compile.py
+++ b/src/julia/tests/test_trace_compile.py
@@ -1,8 +1,5 @@
-import os
+import re
 from pathlib import Path
-from subprocess import check_call
-
-import pytest
 
 from .test_compatible_exe import runcode
 from .utils import skip_in_windows
@@ -12,9 +9,9 @@ from .utils import skip_in_windows
 def test_trace_file_created(tmpdir):
     trace_compile_path = Path(tmpdir) / "trace_compile.jl"
     runcode(
-        """
+        f"""
     from julia.api import Julia
-    jl = Julia(trace_compile="{}")
+    jl = Julia(trace_compile="{trace_compile_path}")
 
     from julia import Main
     Main.sin(2.0)
@@ -24,3 +21,9 @@ def test_trace_file_created(tmpdir):
     )
     assert (trace_compile_path).exists()
     assert len(trace_compile_path.read_text().strip()) > 0
+
+    # check whether the sin precompilation directive is included in the file
+    trace_compile_content = Path(trace_compile_path).read_text().strip()
+    lines = [x for x in trace_compile_content.split("\n") if len(x) > 0]
+    expected_precompile_line = r"precompile\(Tuple\{typeof\([A-Za-z]+\.sin\), Float64\}\)"
+    assert any([re.match(expected_precompile_line, x) is not None for x in lines])

--- a/src/julia/tests/test_trace_compile.py
+++ b/src/julia/tests/test_trace_compile.py
@@ -8,16 +8,17 @@ from .test_compatible_exe import runcode
 
 
 def test_trace_file_created(tmpdir):
-    currdir = os.getcwd()
-    os.chdir(str(tmpdir))
+    trace_compile_path = Path(tmpdir) / "trace_compile.jl"
     runcode(
         """
     from julia.api import Julia
-    jl = Julia(trace_compile="trace_compile.jl")
+    jl = Julia(trace_compile="{}")
 
     from julia import Main
     Main.sin(2.0)
-    """
+    """.format(
+            str(trace_compile_path)
+        )
     )
-    os.chdir(currdir)
-    assert (Path(tmpdir) / "trace_compile.jl").exists()
+    assert (trace_compile_path).exists()
+    assert len(trace_compile_path.read_text().strip()) > 0


### PR DESCRIPTION
It'd be nice to be able to trace the compilation performed by Julia called via PyJulia. The main use case is for the precompilation of a Julia library triggered primarily through their Python interface.

The change is a single line adding the `trace-compile` option.