### PR TITLE
Fix PyJulia on Python 3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ jobs:
           - '1.4'
           - '1.7'
           - '1.8'
+          - '1.9'
         exclude:
           - os: ubuntu-latest
             architecture: x86

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,10 +20,9 @@ jobs:
         architecture: [x64, x86]
         python-version:
           - '3.9'
-          - '3.10'
+          - '3.12'
         julia-version:
           - '1.4'
-          - '1.6'
           - '1.7'
           - '1.8'
         exclude:

--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,8 @@ setup(name='julia',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3.11',
+        'Programming Language :: Python :: 3.12',
       ],
       url='http://julialang.org',
       project_urls={

--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -230,7 +230,7 @@ class JuliaImporter(MetaPathFinder):
             filepath = os.path.join(os.path.dirname(__file__), filename)
             if os.path.isfile(filepath + ".py") or os.path.isdir(filepath):
                 return
-            return ModuleSpec(fullname, JuliaModuleLoader())
+            return ModuleSpec(fullname, JuliaModuleLoader(), origin=filepath)
 
 
 class JuliaModuleLoader(Loader):
@@ -240,7 +240,10 @@ class JuliaModuleLoader(Loader):
         return julia
 
     def exec_module(self, module):
-        fullname = module.__name__
+        pass
+
+    def create_module(self, spec):
+        fullname = spec.name
         juliapath = remove_prefix(fullname, "julia.")
         if juliapath == 'Main':
             return sys.modules.setdefault(fullname,

--- a/src/julia/core.py
+++ b/src/julia/core.py
@@ -191,7 +191,7 @@ class JuliaModule(ModuleType):
         if self._julia.isamodule(jl_fullname):
             realname = self._julia.fullname(self._julia.eval(jl_fullname))
             if self._julia.isdefined(realname):
-                return self.__loader__.load_module("julia." + realname)
+                return self.__loader__.create_module(_find_spec_from_fullname("julia." + realname))
             # Otherwise, it may be, e.g., "Main.anonymous", created by
             # Module().
 
@@ -225,13 +225,16 @@ class JuliaMainModule(JuliaModule):
 class JuliaImporter(MetaPathFinder):
 
     def find_spec(self, fullname, path=None, target=None):
-        if fullname.startswith("julia."):
-            filename = fullname.split(".", 2)[1]
-            filepath = os.path.join(os.path.dirname(__file__), filename)
-            if os.path.isfile(filepath + ".py") or os.path.isdir(filepath):
-                return
-            return ModuleSpec(fullname, JuliaModuleLoader(), origin=filepath)
+        return _find_spec_from_fullname(fullname)
 
+
+def _find_spec_from_fullname(fullname):
+    if fullname.startswith("julia."):
+        filename = fullname.split(".", 2)[1]
+        filepath = os.path.join(os.path.dirname(__file__), filename)
+        if os.path.isfile(filepath + ".py") or os.path.isdir(filepath):
+            return
+        return ModuleSpec(fullname, JuliaModuleLoader(), origin=filepath)
 
 class JuliaModuleLoader(Loader):
     @property

--- a/src/julia/release.py
+++ b/src/julia/release.py
@@ -1,5 +1,5 @@
 # This file is executed via setup.py and imported via __init__.py
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 # For Python versioning scheme, see:
 # https://www.python.org/dev/peps/pep-0440/#version-scheme


### PR DESCRIPTION
cc @mkitti do you think you could give this a look over? It still seems like there are some issues even though `from julia import Main` doesn't blow up... Any help appreciated.

This updates the importlib API according to what was noticed in https://github.com/JuliaPy/pyjulia/issues/509 (which were giving deprecation warnings, we simply didn't update in time).

This is a lot of guess work about the importlib API: https://docs.python.org/3/library/importlib.html, so I'd appreciate if someone could give a close reading.

I found this stackoverflow answer to be particularly helpful: https://stackoverflow.com/a/43573798/2689923

cc @IlyaOrson this should finally fix the PySR issue you saw (the proper way!)