### PR TITLE
Fix PyPI test with missing setuptools

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -63,6 +63,9 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: 3.9
+      - name: Install setuptools and wheel
+        run: |
+          python -m pip install --user setuptools wheel
       - name: Download from TestPyPI
         run: |
           pip download --dest dist --no-deps --index-url https://test.pypi.org/simple/ ${{ matrix.package }}


### PR DESCRIPTION
Already fixed on release branches; this just adds the same fix to master.

It seems that setuptools is no longer found on `test.pypi.org/simple`, so needs to be installed prior to the test.