### PR TITLE
Don't fail CI on failing Windows 32-bit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,6 +78,8 @@ jobs:
         run: python ci/install_pycall.py
       - name: Run test
         run: python -m tox -- --verbose --cov=julia
+        id: tox-tests
+        continue-on-error: ${{ matrix.julia-version == 'nightly' || (matrix.os == 'windows-latest' && matrix.architecture == 'x86') }}
         env:
           CI: 'true'  # run tests marked by @only_in_ci
           TOXENV: py
@@ -86,9 +88,13 @@ jobs:
         if: always()
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
+        if: steps.tox-tests.outcome == 'success'
         with:
           file: ./coverage.xml
           name: codecov-umbrella
+      - name: Report allowed failures
+        if: steps.tox-tests.outcome != 'success'
+        run: echo "Allowed failure for this configuration."
 
   check:
     runs-on: ubuntu-latest


### PR DESCRIPTION
cc @mkitti @Moelf

This changes the main test suite to not fail the entire CI (with the red X) if the 32-bit windows test fails. This action runner seems extremely flaky, and is currently broken, and I am worried that the red X loses its significance to us if some tests are implicitly expected to fail. (Not to mention it is a visual cue for a package being maintained or not)

I also skip failures on julia-nightly. They are still visible though if you read the logs.

(I remember there was some discussion of whether 32-bit Windows is actually supported or not..... I forget where that was; maybe a PyCall.jl issue? Or in juliaup?)